### PR TITLE
Use setuptools for building and installing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@
 tobedel/
 build/
 dist/
+src/pysmo.aimbat.egg-info/
 .DS_Store

--- a/setup.py
+++ b/setup.py
@@ -15,23 +15,26 @@ et al., 2003) plotting and phase picking functionalities are replicated
 and enhanced.
 """
 
+from setuptools import find_packages
 from numpy.distutils.core import setup, Extension
 
 doclines = __doc__.split("\n")
 version = open('Version.txt').read().split()[0]
 
-setup(name='pysmo.aimbat',
-	version=version,
-	description=doclines[0],
-	author='Xiaoting Lou',
-	author_email='xlou@u.northwestern.edu',
-	package_dir={'pysmo.aimbat': 'src/pysmo/aimbat', 'pysmo':'src/pysmo'},
-	packages=['pysmo.aimbat', 'pysmo'],
-	url='http://www.earth.northwestern.edu/~xlou/aimbat.html',
-	ext_package='pysmo.aimbat',
-	ext_modules=[Extension('xcorrf90', ['src/pysmo/aimbat/xcorr.f90'])],
-	package_data={'pysmo.aimbat': ['ttdefaults.conf', 'Readme.txt', 'Version.txt', 'License.txt', 'Changelog.txt']},
-	long_description="\n".join(doclines[2:]),
-	license='GNU General Public License, Version 3 (GPLv3)',
-	platforms=['Mac OS X', 'Linux/Unix', 'Windows']
-	)
+setup(
+    name='pysmo.aimbat',
+    version=version,
+    description=doclines[0],
+    long_description="\n".join(doclines[2:]),
+    author='Xiaoting Lou',
+    author_email='xlou@u.northwestern.edu',
+    license='GNU General Public License, Version 3 (GPLv3)',
+    url='http://www.earth.northwestern.edu/~xlou/aimbat.html',
+    package_data={'pysmo.aimbat': ['ttdefaults.conf', 'Readme.txt', 'Version.txt', 'License.txt', 'Changelog.txt']},
+    package_dir={'':'src' },
+    packages=find_packages(where='./src'),
+    ext_package='pysmo.aimbat',
+    ext_modules=[Extension('xcorrf90', ['src/pysmo/aimbat/xcorr.f90'])],
+    zip_safe=False,
+    platforms=['Mac OS X', 'Linux/Unix', 'Windows']
+)

--- a/src/pysmo/__init__.py
+++ b/src/pysmo/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/src/pysmo/aimbat/__init__.py
+++ b/src/pysmo/aimbat/__init__.py
@@ -16,3 +16,4 @@ et al., 2003) plotting and phase picking functionalities are replicated
 and enhanced.
 
 """
+name = 'aimbat'


### PR DESCRIPTION
This uses newer setuptools in setup.py for packaging. Should fix namespace issues and allow for clean uninstalling with `sudo pip uninstall pysmo.aimbat`