### PR TITLE
Make fortran optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ def run_setup(with_fortran=True):
     )
 
 try:
-    run_setup()
+    run_setup(with_fortan=True)
 except:
     print('*' * 75)
     print("Unable to build fortran extensions, building in pure python")

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,10 @@ def run_setup(with_fortran=True):
     )
 
 try:
-    run_setup(with_fortan=True)
+    print('*' * 75)
+    print("Attempting to build fortran extension for cross-correlation")
+    run_setup()
+    print('*' * 75)
 except:
     print('*' * 75)
     print("Unable to build fortran extensions, building in pure python")

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python
-""" 
+"""
 AIMBAT: Automated and Interactive Measurement of Body-wave Arrival Times.
 
-AIMBAT is an open-source software package for efficiently measuring teleseismic 
-body wave arrival times for large seismic arrays (Lou et al., 2013). It is 
-based on a widely used method called MCCC (multi-channel cross-correlation) 
-developed by VanDecar and Crosson (1990). The package is automated in the 
-sense of initially aligning seismograms for MCCC which is achieved by an 
-ICCS (iterative cross-correlation and stack) algorithm. Meanwhile, a 
-graphical user interface is built to perform seismogram quality control 
-interactively. Therefore, user processing time is reduced while valuable 
-input from a user\'s expertise is retained. As a byproduct, SAC (Goldstein 
-et al., 2003) plotting and phase picking functionalities are replicated 
+AIMBAT is an open-source software package for efficiently measuring teleseismic
+body wave arrival times for large seismic arrays (Lou et al., 2013). It is
+based on a widely used method called MCCC (multi-channel cross-correlation)
+developed by VanDecar and Crosson (1990). The package is automated in the
+sense of initially aligning seismograms for MCCC which is achieved by an
+ICCS (iterative cross-correlation and stack) algorithm. Meanwhile, a
+graphical user interface is built to perform seismogram quality control
+interactively. Therefore, user processing time is reduced while valuable
+input from a user\'s expertise is retained. As a byproduct, SAC (Goldstein
+et al., 2003) plotting and phase picking functionalities are replicated
 and enhanced.
 """
 
@@ -20,38 +20,60 @@ from numpy.distutils.core import setup, Extension
 
 doclines = __doc__.split("\n")
 
-setup(
-    name='pysmo.aimbat',
-    use_scm_version=True,
-    setup_requires=['setuptools_scm'],
-    description=doclines[0],
-    long_description="\n".join(doclines[2:]),
-    author='Xiaoting Lou',
-    author_email='xlou@u.northwestern.edu',
-    license='GNU General Public License, Version 3 (GPLv3)',
-    url='http://www.earth.northwestern.edu/~xlou/aimbat.html',
-    package_data={'pysmo.aimbat': ['ttdefaults.conf', 'Readme.txt', 'Version.txt', 'License.txt', 'Changelog.txt']},
-    package_dir={'':'src' },
-    packages=find_packages(where='./src'),
-    ext_package='pysmo.aimbat',
-    ext_modules=[Extension('xcorrf90', ['src/pysmo/aimbat/xcorr.f90'])],
-    zip_safe=False,
-    platforms=['Mac OS X', 'Linux/Unix', 'Windows'],
-    install_requires=[i.strip() for i in open("requirements.txt").readlines()],
-    entry_points={
-        'console_scripts': [
-            'aimbat-mccc=pysmo.aimbat.algmccc:main',
-            'aimbat-iccs=pysmo.aimbat.algiccs:main',
-            'aimbat-sac2pkl=pysmo.aimbat.sacpickle:main',
-            'aimbat-sacp1=pysmo.aimbat.plotphase:sacp1_standalone',
-            'aimbat-sacp2=pysmo.aimbat.plotphase:sacp2_standalone',
-            'aimbat-sacpaz=pysmo.aimbat.plotphase:sacpaz_standalone',
-            'aimbat-sacpbaz=pysmo.aimbat.plotphase:sacpbaz_standalone',
-            'aimbat-sacplot=pysmo.aimbat.plotphase:sacplot_standalone',
-            'aimbat-sacprs=pysmo.aimbat.plotphase:sacprs_standalone',
-            'aimbat-sacppk=pysmo.aimbat.pickphase:sacppk_standalone',
-            'aimbat-ttpick=pysmo.aimbat.qualctrl:main',
-            'aimbat-qttpick=pysmo.aimbat.ttguiqt:main',
-        ]
-    },
-)
+def run_setup(with_fortran=True):
+    if with_fortran is True:
+        fortran_kw = dict(
+                ext_modules=[
+                    Extension(
+                        'xcorrf90',
+                        sources=['src/pysmo/aimbat/xcorr.f90'],)
+                ]
+        )
+    else:
+        fortran_kw = {}
+
+    setup(
+        name='pysmo.aimbat',
+        use_scm_version=True,
+        setup_requires=['setuptools_scm'],
+        description=doclines[0],
+        long_description="\n".join(doclines[2:]),
+        author='Xiaoting Lou',
+        author_email='xlou@u.northwestern.edu',
+        license='GNU General Public License, Version 3 (GPLv3)',
+        url='http://www.earth.northwestern.edu/~xlou/aimbat.html',
+        package_data={'pysmo.aimbat': ['ttdefaults.conf', 'Readme.txt', 'Version.txt',
+                                       'License.txt', 'Changelog.txt']},
+        package_dir={'':'src'},
+        packages=find_packages(where='./src'),
+        ext_package='pysmo.aimbat',
+        zip_safe=False,
+        platforms=['Mac OS X', 'Linux/Unix', 'Windows'],
+        install_requires=[i.strip() for i in open("requirements.txt").readlines()],
+        entry_points={
+            'console_scripts': [
+                'aimbat-mccc=pysmo.aimbat.algmccc:main',
+                'aimbat-iccs=pysmo.aimbat.algiccs:main',
+                'aimbat-sac2pkl=pysmo.aimbat.sacpickle:main',
+                'aimbat-sacp1=pysmo.aimbat.plotphase:sacp1_standalone',
+                'aimbat-sacp2=pysmo.aimbat.plotphase:sacp2_standalone',
+                'aimbat-sacpaz=pysmo.aimbat.plotphase:sacpaz_standalone',
+                'aimbat-sacpbaz=pysmo.aimbat.plotphase:sacpbaz_standalone',
+                'aimbat-sacplot=pysmo.aimbat.plotphase:sacplot_standalone',
+                'aimbat-sacprs=pysmo.aimbat.plotphase:sacprs_standalone',
+                'aimbat-sacppk=pysmo.aimbat.pickphase:sacppk_standalone',
+                'aimbat-ttpick=pysmo.aimbat.qualctrl:main',
+                'aimbat-qttpick=pysmo.aimbat.ttguiqt:main',
+            ]
+        },
+        **fortran_kw
+    )
+
+try:
+    run_setup()
+except:
+    print('*' * 75)
+    print("Unable to build fortran extensions, building in pure python")
+    print("Cross-correlation will be slower")
+    print('*' * 75)
+    run_setup(with_fortran=False)

--- a/setup.py
+++ b/setup.py
@@ -23,11 +23,12 @@ doclines = __doc__.split("\n")
 def run_setup(with_fortran=True):
     if with_fortran is True:
         fortran_kw = dict(
-                ext_modules=[
-                    Extension(
-                        'xcorrf90',
-                        sources=['src/pysmo/aimbat/xcorr.f90'],)
-                ]
+            ext_modules=[
+                Extension(
+                    'xcorrf90',
+                    sources=['src/pysmo/aimbat/xcorr.f90'],
+                )
+            ]
         )
     else:
         fortran_kw = {}

--- a/src/pysmo/aimbat/algiccs.py
+++ b/src/pysmo/aimbat/algiccs.py
@@ -13,14 +13,16 @@ Python module for the ICCS (iterative cross-correlation and stack) algorithm.
     Xiaoting Lou
 
 :license:
-    GNU General Public License, Version 3 (GPLv3) 
+    GNU General Public License, Version 3 (GPLv3)
     http://www.gnu.org/licenses/gpl.html
 """
 
+import os
+import sys
+import copy
+from optparse import OptionParser
 from numpy import array, ones, zeros, sqrt, dot, corrcoef, mean, transpose, linspace
 from numpy import linalg as LA
-import os, sys, copy
-from optparse import OptionParser
 from pysmo.aimbat import ttconfig
 from pysmo.aimbat import qualsort
 from pysmo.aimbat import sacpickle as sacpkl
@@ -36,35 +38,39 @@ def getOptions():
     minccc = 0.5
     minsnr = 0.5
     mincoh = 0.0
-    minqual = minccc, minsnr, mincoh    
+    minqual = minccc, minsnr, mincoh
     minnsel = 5
     parser.set_defaults(twcorr=twcorr)
     parser.set_defaults(ipick=ipick)
     parser.set_defaults(wpick=wpick)
     parser.set_defaults(minqual=minqual)
     parser.set_defaults(minnsel=minnsel)
-    parser.add_option('-S', '--srate',  dest='srate', type='float',
-        help='Sampling rate to load SAC data. Default is None, use the original rate of first files.')
-    parser.add_option('-i', '--ipick',  dest='ipick', type='str',
-        help='SAC header variable to read input time pick.')
-    parser.add_option('-w', '--wpick',  dest='wpick', type='str',
-        help='SAC header variable to write output time pick.')
+    parser.add_option('-S', '--srate', dest='srate', type='float',
+                      help='Sampling rate to load SAC data. Default is None, '
+                      'use the original rate of first files.')
+    parser.add_option('-i', '--ipick', dest='ipick', type='str',
+                      help='SAC header variable to read input time pick.')
+    parser.add_option('-w', '--wpick', dest='wpick', type='str',
+                      help='SAC header variable to write output time pick.')
     parser.add_option('-t', '--twcorr', dest='twcorr', type='float', nargs=2,
-        help='Time window for cross-correlation. Default is [{:.1f}, {:.1f}] s.'.format(twcorr[0],twcorr[1]))
-    parser.add_option('-f', '--fstack',  dest='fstack', type='str',
-        help='SAC file name to save final array stack.')
+                      help='Time window for cross-correlation. Default is '
+                      '[{:.1f}, {:.1f}] s.'.format(twcorr[0], twcorr[1]))
+    parser.add_option('-f', '--fstack', dest='fstack', type='str',
+                      help='SAC file name to save final array stack.')
     parser.add_option('-p', '--plotiter', action="store_true", dest='plotiter',
-        help='Plot array stack of each iteration.')
+                      help='Plot array stack of each iteration.')
     parser.add_option('-a', '--auto_on', action="store_true", dest='auto_on',
-        help='Run ICCS and select/delete seismograms automatically.')
+                      help='Run ICCS and select/delete seismograms automatically.')
     parser.add_option('-A', '--auto_on_all', action="store_true", dest='auto_on_all',
-        help='Run ICCS with -a option but initially use all seismograms.')
-    parser.add_option('-q', '--minqual',  dest='minqual', type='float', nargs=3,
-        help='Minimum quality factor (ccc,snr,coh) for auto selection. Defaults are {:.2f} {:.2f} {:.2f}.'.format(minccc, minsnr, mincoh))
-    parser.add_option('-n', '--minnsel',  dest='minnsel', type='int',
-        help='Minimum number of selected seismograms for auto selection. Default is {:d}.'.format(minnsel))
+                      help='Run ICCS with -a option but initially use all seismograms.')
+    parser.add_option('-q', '--minqual', dest='minqual', type='float', nargs=3,
+                      help='Minimum quality factor (ccc,snr,coh) for auto selection. '
+                      'Defaults are {:.2f} {:.2f} {:.2f}.'.format(minccc, minsnr, mincoh))
+    parser.add_option('-n', '--minnsel', dest='minnsel', type='int',
+                      help='Minimum number of selected seismograms for auto selection. '
+                      'Default is {:d}.'.format(minnsel))
     opts, files = parser.parse_args(sys.argv[1:])
-    if len(files) == 0:
+    if not files:
         print(parser.usage)
         sys.exit()
     return opts, files
@@ -93,19 +99,19 @@ def weightStack(data, wgts, taperwidth, tapertype):
 def normWeightStack(data, wgts, taperwidth, tapertype):
     """ Calculate array stack by averaging with weighting and normalization.
     """
-    mdata = [ d/max(d)  for d in data ]
+    mdata = [d/max(d)  for d in data]
     sdata = mean(transpose(mdata) * wgts, 1)
     sdata = sacpkl.taper(sdata, taperwidth, tapertype)
     return sdata
 
 def ccWeightStack(saclist, opts):
-    """ 
+    """
     Align seismograms by the iterative cross-correlation and stack algorithm.
 
     Parameters
     ----------
     opts.delta : sample time interval
-    opts.ccpara : a class instance for ICCS parameters 
+    opts.ccpara : a class instance for ICCS parameters
         * qqhdrs : SAC headers to save quality factors: ccc, snr, coh
         * maxiter :    maximum number of iteration
         * converg :    convergence critrion
@@ -134,7 +140,7 @@ def ccWeightStack(saclist, opts):
     else:
         print('Unknown convergence criterion: {:s}. Exit.'.format(convtype))
         sys.exit()
-    
+   
     out = '\n--> Run ICCS at window [{0:5.1f}, {1:5.1f}] wrt {2:s}. Write to header: {3:s}'
     print(out.format(twcorr[0], twcorr[1], cchdr0, cchdr1))
     print('    Convergence criterion: {:s}'.format(convtype))
@@ -144,7 +150,7 @@ def ccWeightStack(saclist, opts):
         wgtcoef = False
     taperwindow = sacpkl.taperWindow(twcorr, taperwidth)
     # get initial time picks
-    tinis = array([ sacdh.gethdr(cchdr0) for sacdh in saclist])
+    tinis = array([sacdh.gethdr(cchdr0) for sacdh in saclist])
     tfins = tinis.copy()
     nseis = len(saclist)
     ccc = zeros(nseis)
@@ -160,12 +166,12 @@ def ccWeightStack(saclist, opts):
         sdata = normWeightStack(windata, wgts, taperwidth, tapertype)
         stkdata.append(sdata)
         if it == 0:
-            print ('=== Iteration {0:d} : epsilon'.format(it))
+            print('=== Iteration {0:d} : epsilon'.format(it))
         else:
             conv = convergence(stkdata[it], stkdata[it-1])
-            print ('=== Iteration {0:d} : {1:8.6f}'.format(it, conv))
+            print('=== Iteration {0:d} : {1:8.6f}'.format(it, conv))
             if conv <= convepsi:
-                print ('    Array stack converged... Done. Mean corrcoef={0:.3f}'.format(mean(ccc)))
+                print('    Array stack converged... Done. Mean corrcoef={0:.3f}'.format(mean(ccc)))
                 break
         # Find time lag at peak correlation between each trace and the array stack.
         # Calculate cross correlation coefficient, signal/noise ratio and temporal coherence
@@ -205,7 +211,7 @@ def ccWeightStack(saclist, opts):
     # also create stack from original data
     datatype = 'data'
     windata = sacpkl.windowData(saclist, nstart, ntotal, taperwidth, tapertype, datatype)
-    sdata  = normWeightStack(windata, wgts, taperwidth, tapertype)
+    sdata = normWeightStack(windata, wgts, taperwidth, tapertype)
     tinimean = mean(tinis)
     tfinmean = mean(tfins)
     stkdh = copy.copy(saclist[0])
@@ -242,26 +248,26 @@ def ccWeightStack(saclist, opts):
     for sacdh, tfin in zip(saclist, tfins):
         sacdh.sethdr(twhdrs[0], tfin+twcorr[0])
         sacdh.sethdr(twhdrs[1], tfin+twcorr[1])
-        sacdh.twindow = tfin+twcorr[0], tfin+twcorr[1] 
-    quas = array([ ccc, snr, coh ])
+        sacdh.twindow = tfin+twcorr[0], tfin+twcorr[1]
+    quas = array([ccc, snr, coh])
     return stkdh, stkdata, quas
 
 def coConverg(stack0, stack1):
-    """ 
+    """
     Calcuate criterion of convergence by correlation coefficient.
     stack0 and stack1 are current stack and stack from last iteration.
     """
     return 1 - corrcoef(stack0, stack1)[0][1]
 
 def reConverg(stack0, stack1):
-    """ 
+    """
     Calcuate criterion of convergence by change of stack.
     stack0 and stack1 are current stack and stack from last iteration.
     """
-    return LA.norm(stack0-stack1,1)/LA.norm(stack0,2)/len(stack0)
+    return LA.norm(stack0-stack1, 1)/LA.norm(stack0, 2)/len(stack0)
 
 def snratio(data, delta, timewindow):
-    """ 
+    """
     Calculate signal/noise ratio within the given time window.
     Time window is relative, such as [-10, 20], to the onset of the arrival.
     """
@@ -272,7 +278,7 @@ def snratio(data, delta, timewindow):
     ns = len(ys)
     rr = LA.norm(ys)/LA.norm(yn)*sqrt(nn)/sqrt(ns)
     if LA.norm(yn) == 0:
-        print ('snr', LA.norm(yn))
+        print('snr', LA.norm(yn))
     ### the same as:
     #rr = sqrt(sum(square(ys))/sum(square(yn))*nn/ns)
     # shoud signal be the whole time seris?
@@ -282,11 +288,11 @@ def snratio(data, delta, timewindow):
     return rr
 
 def coherence(datai, datas):
-    """ 
+    """
     Calculate time domain coherence.
     Coherence is 1 - sin of the angle made by two vectors: di and ds.
     Di is data vector, and ds is the unit vector of array stack.
-    res(di) = di - (di . ds) ds 
+    res(di) = di - (di . ds) ds
     coh(di) = 1 - res(di) / ||di||
     """
     return 1 - LA.norm(datai - dot(datai, datas)*datas)/LA.norm(datai)
@@ -308,9 +314,9 @@ def autoiccs(gsac, opts):
     minqual = opts.minqual
     minnsel = opts.minnsel
     minccc, minsnr, mincoh = minqual
-    
+
     selist, delist = qualsort.seleSeis(saclist)
-    print ('\n*** Run ICCS until all low quality seismograms removed: Min_ccc={0:.2f} Min_snr={1:.1f} Min_coh={2:.2f} *** '.format(minccc,minsnr,mincoh))
+    print('\n*** Run ICCS until all low quality seismograms removed: Min_ccc={0:.2f} Min_snr={1:.1f} Min_coh={2:.2f} *** '.format(minccc, minsnr, mincoh))
     rerun = True
     while rerun and len(selist) >= minnsel:
         stkdh, stkdata, quas = ccWeightStack(selist, opts)
@@ -323,17 +329,17 @@ def autoiccs(gsac, opts):
                 inddel.append(i)
                 sacdh.sethdr(hdrsel, 'False')
                 sacdh.selected = False
-                print ('--> Seismogram: {0:s} quality factors {1:.2f} {2:.2f} {3:.2f} < min. Deleted. '.format(sacdh.filename, ccc, snr, coh))
+                print('--> Seismogram: {0:s} quality factors {1:.2f} {2:.2f} {3:.2f} < min. Deleted. '.format(sacdh.filename, ccc, snr, coh))
             else:
                 indsel.append(i)
         if len(inddel) > 0:
-            selist = [ selist[i] for i in indsel ]
+            selist = [selist[i] for i in indsel]
         else:
             rerun = False
             gsac.stkdh = stkdh
     gsac.selist = selist
     nsel = len(selist)
-    print ('\nDone selecting seismograms: {0:d} out of {1:d} selected.'.format(nsel, len(saclist)))
+    print('\nDone selecting seismograms: {0:d} out of {1:d} selected.'.format(nsel, len(saclist)))
 
     save = input('Save to file? [y/n] \n')
     if save[0].lower() == 'y':
@@ -341,15 +347,15 @@ def autoiccs(gsac, opts):
             for sacdh in saclist: sacdh.writeHdrs()
             gsac.stkdh.savesac()
         elif opts.filemode == 'pkl':
-            print (' Saving gsac to pickle file...')
+            print(' Saving gsac to pickle file...')
             sacpkl.writePickle(gsac, opts.pklfile, opts.zipmode)
             if opts.zipmode is not None:
                 pklfile = opts.pklfile + '.' + opts.zipmode
             else:
                 pklfile = opts.pklfile
-            if nsel < minnsel: 
+            if nsel < minnsel:
                 os.rename(pklfile, 'deleted.'+pklfile)
-                print ('  Less than {:d} seismograms selected. Remove pkl.'.format(minnsel))
+                print('  Less than {:d} seismograms selected. Remove pkl.'.format(minnsel))
 
 
 
@@ -368,14 +374,14 @@ def checkCoverage(gsac, opts, textra=0.0):
         e = b + (sacdh.npts-1)*sacdh.delta
         if b-textra > t0+tw0 or e+textra < t0+tw1:
             inddel.append(i)
-            print ('Seismogram {0:s} does not have enough sample. Deleted.'.format(sacdh.filename))
+            print('Seismogram {0:s} does not have enough sample. Deleted.'.format(sacdh.filename))
         elif LA.norm(sacdh.data) == 0.0:
             inddel.append(i)
-            print ('Seismogram {0:s} has zero L2 norm. Deleted.'.format(sacdh.filename))
+            print('Seismogram {0:s} has zero L2 norm. Deleted.'.format(sacdh.filename))
         else:
             indsel.append(i)
     if inddel != []:
-        gsac.saclist = [ saclist[i] for i in indsel ]
+        gsac.saclist = [saclist[i] for i in indsel]
         #print ('Updating gsac pickle file..')
         #writePickle(gsac, opts.pklfile, opts.zipmode)
 
@@ -388,13 +394,13 @@ def main():
     ccpara.twcorr = opts.twcorr
     ccpara.cchdrs = [opts.ipick, opts.wpick]
     # check data coverage, initialize quality factors
-    checkCoverage(gsac, opts) 
+    checkCoverage(gsac, opts)
     qualsort.initQual(gsac.saclist, opts.ccpara.hdrsel, opts.ccpara.qheaders)
 
     if opts.auto_on:
         autoiccs(gsac, opts)
     elif opts.auto_on_all:
-        print ('Selecting all seismograms..')
+        print('Selecting all seismograms..')
         hdrsel = opts.ccpara.hdrsel
         for sacdh in gsac.saclist:
             sacdh.selected = True

--- a/src/pysmo/aimbat/algmccc.py
+++ b/src/pysmo/aimbat/algmccc.py
@@ -16,15 +16,16 @@ Code transcribed from the original MCCC 3.0 fortran version using the same funct
     Xiaoting Lou, John VanDecar
 
 :license:
-    GNU General Public License, Version 3 (GPLv3) 
+    GNU General Public License, Version 3 (GPLv3)
     http://www.gnu.org/licenses/gpl.html
 """
 
 
-from numpy import array, mean, dot, zeros, log, transpose, concatenate, exp, sum, std, shape, sqrt, argsort, identity 
-import os, sys
+import os
+import sys
 from time import strftime, tzname
 from optparse import OptionParser
+from numpy import array, mean, dot, zeros, log, transpose, concatenate, exp, sum, std, shape, sqrt, argsort, identity 
 from pysmo.aimbat import ttconfig
 from pysmo.aimbat import qualsort
 from pysmo.aimbat import sacpickle as sacpkl
@@ -32,36 +33,39 @@ from pysmo.aimbat.prepdata import findPhase
 
 
 def getOptions():
-    """ 
-    Parse arguments and options from command line. 
+    """
+    Parse arguments and options from command line.
     No default value is given here because it will override values from configuration file.
     """
     usage = "Usage: %prog [options] <sacfile(s) or a picklefile>"
     parser = OptionParser(usage=usage)
-    parser.add_option('-S', '--srate',  dest='srate', type='float',
-        help='Sampling rate to load SAC data. Default is None, use the original rate of first file.')
-    parser.add_option('-W', '--window',  dest='window', type='float',
-        help='Use a correlation window length in seconds.')
-    parser.add_option('-I', '--inset',  dest='inset', type='float',
-        help='Use a time length of inset seconds from initial pick time to start of correlation window.')
-    parser.add_option('-T', '--taper',  dest='taper', type='float',
-        help='Apply a Hanning taper with width of taper seconds. Half of taper extends beyond both sides of window.')
-    parser.add_option('-s', '--shift',  dest='shift', type='int',
-        help='Shift in number of samples in cross-correlation.')
-    parser.add_option('-i', '--ipick',  dest='ipick', type='str',
-        help='SAC header variable to read initial time pick.')
-    parser.add_option('-w', '--wpick',  dest='wpick', type='str',
-        help='SAC header variable to write MCCC time pick.')
-    parser.add_option('-p', '--phase',  dest='phase', type='str',
-        help='Seismic phase name: P/S .')
-    parser.add_option('-l', '--lsqr',  dest='lsqr', type='str',
-        help='LSQR method to solve eqs: nowe, lnco, lnre.')
-    parser.add_option('-o', '--ofilename',  dest='ofilename', type='str',
-        help='Output file name. Default is $evdate.mc$phase')
+    parser.add_option('-S', '--srate', dest='srate', type='float',
+                      help='Sampling rate to load SAC data. Default is None, '
+                      'use the original rate of first file.')
+    parser.add_option('-W', '--window', dest='window', type='float',
+                      help='Use a correlation window length in seconds.')
+    parser.add_option('-I', '--inset', dest='inset', type='float',
+                      help='Use a time length of inset seconds from initial pick '
+                      'time to start of correlation window.')
+    parser.add_option('-T', '--taper', dest='taper', type='float',
+                      help='Apply a Hanning taper with width of taper seconds. '
+                      'Half of taper extends beyond both sides of window.')
+    parser.add_option('-s', '--shift', dest='shift', type='int',
+                      help='Shift in number of samples in cross-correlation.')
+    parser.add_option('-i', '--ipick', dest='ipick', type='str',
+                      help='SAC header variable to read initial time pick.')
+    parser.add_option('-w', '--wpick', dest='wpick', type='str',
+                      help='SAC header variable to write MCCC time pick.')
+    parser.add_option('-p', '--phase', dest='phase', type='str',
+                      help='Seismic phase name: P/S .')
+    parser.add_option('-l', '--lsqr', dest='lsqr', type='str',
+                      help='LSQR method to solve eqs: nowe, lnco, lnre.')
+    parser.add_option('-o', '--ofilename', dest='ofilename', type='str',
+                      help='Output file name. Default is $evdate.mc$phase')
     parser.add_option('-a', '--allseis', action="store_true", dest='allseis_on',
-        help='Use all seismograms. Default to use selected ones.')
+                      help='Use all seismograms. Default to use selected ones.')
     opts, files = parser.parse_args(sys.argv[1:])
-    if len(files) == 0:
+    if not files:
         print(parser.usage)
         sys.exit()
     return opts, files
@@ -131,9 +135,9 @@ def corread(saclist, ipick, timewindow, taperwindow, tapertype):
     """
     tw = timewindow[1] - timewindow[0]
     taperwidth = taperwindow/(taperwindow+tw)
-    reftimes = array([ sacdh.gethdr(ipick) for sacdh in saclist])
+    reftimes = array([sacdh.gethdr(ipick) for sacdh in saclist])
     if -12345.0 in reftimes:
-        print ('Not all seismograms has ipick={:s} set. Exit.'.format(ipick))
+        print('Not all seismograms has ipick={:s} set. Exit.'.format(ipick))
         sys.exit()
         #return
     nstart, ntotal = sacpkl.windowIndex(saclist, reftimes, timewindow, taperwindow)
@@ -141,7 +145,7 @@ def corread(saclist, ipick, timewindow, taperwindow, tapertype):
     return windata, reftimes
 
 def corrmax(datai, timei, dataj, timej, mcpara):
-    """ 
+    """
     Calculate cross-correlation derived relative delay times by calling one of the xcorr functions.
             dt_ij = t_i - t_j - tau_max
     where t_i and t_j are initial time picks for the i-th and j-th traces,
@@ -154,7 +158,7 @@ def corrmax(datai, timei, dataj, timej, mcpara):
     return timei - timej - delay*delta, ccmax
 
 def corrcff_fish(ccmatrix):
-    """ 
+    """
     Calculate mean and standard deviation of correlation coefficients
     using Fisher's transform:
             z = 0.5 * ln((1+r)/(1-r))
@@ -168,7 +172,7 @@ def corrcff_fish(ccmatrix):
     nsta = len(ccmatrix)
     ccmean, ccstd = zeros(nsta), zeros(nsta)
     for i in range(nsta):
-        z = concatenate((fish[i,0:i], fish[i,i+1:nsta]))
+        z = concatenate((fish[i, 0:i], fish[i, i+1:nsta]))
         mz = mean(z)
         ccmean[i] = (exp(2*mz)-1)/(exp(2*mz)+1)
         ccstd[i] = std(z, ddof=1)
@@ -181,28 +185,28 @@ def corrcff(ccmatrix):
     nsta = len(ccmatrix)
     ccmean, ccstd = zeros(nsta), zeros(nsta)
     for i in range(nsta):
-        z = concatenate((fish[i,0:i], fish[i,i+1:nsta]))
+        z = concatenate((fish[i, 0:i], fish[i, i+1:nsta]))
         ccmean[i] = mean(z)
-        ccstd[i]  = std(z, ddof=1)
+        ccstd[i] = std(z, ddof=1)
     return ccmean, ccstd
 
 def correrr(dtmatrix, invmodel):
-    """ 
+    """
     Calculate the rms misfit between cross correlated derived relative delay times
     and least-squares solution:
         res_ij = dt_ij - (t_i - t_j)
     """
     nsta = len(dtmatrix)
-    resmatrix = zeros((nsta,nsta))
+    resmatrix = zeros((nsta, nsta))
     for i in range(nsta):
-        for j in range(i+1,nsta):
-            resmatrix[i, j] = dtmatrix[i,j] - (invmodel[i] - invmodel[j])
+        for j in range(i+1, nsta):
+            resmatrix[i, j] = dtmatrix[i, j] - (invmodel[i] - invmodel[j])
     resmatrix -= transpose(resmatrix)
-    rms = sqrt(sum(resmatrix**2,0)/(nsta-2))
+    rms = sqrt(sum(resmatrix**2, 0)/(nsta-2))
     return rms, resmatrix
 
 def corrmat(windata, reftimes, mcpara):
-    """ 
+    """
     Build matrices of cross-correlation derived relative delay times for least-squares solution.
             A * t = dt
     invmatrix A: sparse n*(n-1)/2+1 by n coefficient matrix including zero mean constraint
@@ -212,13 +216,13 @@ def corrmat(windata, reftimes, mcpara):
     nsta = len(windata)
     nrow = nsta*(nsta-1)//2 + 1
     invdata = zeros(nrow)
-    invmatrix = zeros((nrow,nsta))
-    ccmatrix = zeros((nsta,nsta))
-    dtmatrix = zeros((nsta,nsta))
+    invmatrix = zeros((nrow, nsta))
+    ccmatrix = zeros((nsta, nsta))
+    dtmatrix = zeros((nsta, nsta))
     k = 0
     for i in range(nsta):
         datai, timei = windata[i], reftimes[i]
-        for j in range(i+1,nsta):
+        for j in range(i+1, nsta):
             dataj, timej = windata[j], reftimes[j]
             delay, ccmax = corrmax(datai, timei, dataj, timej, mcpara)
             invdata[k] = delay
@@ -232,7 +236,7 @@ def corrmat(windata, reftimes, mcpara):
     return invmatrix, invdata, ccmatrix, dtmatrix
 
 def corrnow(invmatrix, invdata):
-    """ 
+    """
     Solve A * t = dt by lease-squares without weighting:
             t = inv(A'A) * A' * dt = 1/n * A' * dt, where A'A = nI
     """
@@ -254,7 +258,7 @@ def corrwgt(invmatrix, invdata, ccmatrix, resmatrix, wgtscheme='correlation', ex
         w = ccmatrix
     elif wgtscheme == 'residual':
         w = resmatrix
-    wgt = [abs(w[i,j]) for i in range(nsta) for j in range(i+1,nsta)]
+    wgt = [abs(w[i, j]) for i in range(nsta) for j in range(i+1, nsta)]
     wgt.append(exwt)
     wgt = identity(nrow)*array(wgt)
     atw = dot(transpose(invmatrix), wgt)
@@ -269,44 +273,44 @@ def WriteFileWithDelay(mcpara, solist, solution, outvar, outcc, t0_times, delay_
     delta = mcpara.delta
     lsqr = mcpara.lsqr
     nsta = len(solist)
-    stalist = [ sacdh.netsta for sacdh in solist ]
-    filelist = [ sacdh.filename.split('/')[-1] for sacdh in solist ]
+    stalist = [sacdh.netsta for sacdh in solist]
+    filelist = [sacdh.filename.split('/')[-1] for sacdh in solist]
     shift, tw, tap = mcpara.shift, mcpara.timewindow, mcpara.taperwindow
 
     # write mc file (with delay times)
     ofile = open(ofilename, 'w')
     tzone = tzname[0]
-    tdate = strftime("%a, %d %b %Y %H:%M:%S") 
+    tdate = strftime("%a, %d %b %Y %H:%M:%S")
     line0 = 'MCCC processed: %s at: %s %s \n' % (kevnm, tdate, tzone)
     line1 = 'station, mccc delay,    std,    cc coeff,  cc std,   pol   , t0_times  , delay_times\n'
-    ofile.write( line0 )
-    ofile.write( line1 )
+    ofile.write(line0)
+    ofile.write(line1)
     fmt = ' {0:<9s} {1:9.4f} {2:9.4f} {3:>9.4f} {4:>9.4f} {5:4d}  {6:<s}  {7:9.4f}  {8:9.4f}\n'
 
-    selist_LonLat = zeros(shape=(len(solist),2))
+    selist_LonLat = zeros(shape=(len(solist), 2))
     nsta = len(solist)
     for i in range(nsta):
         dt, err, cc, ccstd = solution[i]
-        selist_LonLat[i] = [solist[i].stlo,solist[i].stla]
-        ofile.write( fmt.format(stalist[i], dt, err, cc, ccstd, 0, filelist[i], t0_times[i], delay_times[i]) )
+        selist_LonLat[i] = [solist[i].stlo, solist[i].stla]
+        ofile.write(fmt.format(stalist[i], dt, err, cc, ccstd, 0, filelist[i], t0_times[i], delay_times[i]))
 
-    ofile.write( 'Mean_arrival_time:  {0:9.4f} \n'.format(itmean) )
+    ofile.write('Mean_arrival_time:  {0:9.4f} \n'.format(itmean))
     if lsqr == 'nowe':
         ofile.write('No weighting of equations. \n')
     elif lsqr == 'lnco':
         ofile.write('LAPACK solution with weighting by corr. coef. \n')
     elif lsqr == 'lnre':
         ofile.write('LAPACK solution with weighting by residuals. \n')
-    fmt = 'Window: %6.2f   Inset: %6.2f  Shift: %6.2f \n' 
+    fmt = 'Window: %6.2f   Inset: %6.2f  Shift: %6.2f \n'
     ofile.write(fmt % (tw[1]-tw[0]-tap, -tw[0]-tap/2., shift*delta))
     fmt = 'Variance: %7.5f   Coefficient: %7.5f  Sample rate: %8.3f \n'
     ofile.write(fmt % (outvar, outcc, 1./delta))
     ofile.write('Taper: %6.2f \n' % tap)
 
     # write phase and event
-    ofile.write( 'Phase: {0:8s} \n'.format(mcpara.phase) )
-    ofile.write( mcpara.evline + '\n' )
-    ofile.close()    
+    ofile.write('Phase: {0:8s} \n'.format(mcpara.phase))
+    ofile.write(mcpara.evline + '\n')
+    ofile.close()
 
     return selist_LonLat, delay_times
 
@@ -316,71 +320,71 @@ def WriteFileOriginal(mcpara, solist, solution, outvar, outcc, itmean):
     delta = mcpara.delta
     lsqr = mcpara.lsqr
     nsta = len(solist)
-    stalist = [ sacdh.netsta for sacdh in solist ]
-    filelist = [ sacdh.filename.split('/')[-1] for sacdh in solist ]
+    stalist = [sacdh.netsta for sacdh in solist]
+    filelist = [sacdh.filename.split('/')[-1] for sacdh in solist]
     shift, tw, tap = mcpara.shift, mcpara.timewindow, mcpara.taperwindow
 
     # write mc file (with delay times)
     ofile = open(ofilename, 'w')
     tzone = tzname[0]
-    tdate = strftime("%a, %d %b %Y %H:%M:%S") 
+    tdate = strftime("%a, %d %b %Y %H:%M:%S")
     line0 = 'MCCC processed: %s at: %s %s \n' % (kevnm, tdate, tzone)
     line1 = 'station, mccc delay,    std,    cc coeff,  cc std,   pol\n'
-    ofile.write( line0 )
-    ofile.write( line1 )
+    ofile.write(line0)
+    ofile.write(line1)
     fmt = ' {0:<9s} {1:9.4f} {2:9.4f} {3:>9.4f} {4:>9.4f} {5:4d}  {6:<s}\n'
 
-    selist_LonLat = zeros(shape=(len(solist),2))
+    selist_LonLat = zeros(shape=(len(solist), 2))
     nsta = len(solist)
     for i in range(nsta):
         dt, err, cc, ccstd = solution[i]
-        selist_LonLat[i] = [solist[i].stlo,solist[i].stla]
-        ofile.write( fmt.format(stalist[i], dt, err, cc, ccstd, 0, filelist[i]))
+        selist_LonLat[i] = [solist[i].stlo, solist[i].stla]
+        ofile.write(fmt.format(stalist[i], dt, err, cc, ccstd, 0, filelist[i]))
 
-    ofile.write( 'Mean_arrival_time:  {0:9.4f} \n'.format(itmean) )
+    ofile.write('Mean_arrival_time:  {0:9.4f} \n'.format(itmean))
     if lsqr == 'nowe':
         ofile.write('No weighting of equations. \n')
     elif lsqr == 'lnco':
         ofile.write('LAPACK solution with weighting by corr. coef. \n')
     elif lsqr == 'lnre':
         ofile.write('LAPACK solution with weighting by residuals. \n')
-    fmt = 'Window: %6.2f   Inset: %6.2f  Shift: %6.2f \n' 
+    fmt = 'Window: %6.2f   Inset: %6.2f  Shift: %6.2f \n'
     ofile.write(fmt % (tw[1]-tw[0]-tap, -tw[0]-tap/2., shift*delta))
     fmt = 'Variance: %7.5f   Coefficient: %7.5f  Sample rate: %8.3f \n'
     ofile.write(fmt % (outvar, outcc, 1./delta))
     ofile.write('Taper: %6.2f \n' % tap)
 
     # write phase and event
-    ofile.write( 'Phase: {0:8s} \n'.format(mcpara.phase) )
-    ofile.write( mcpara.evline + '\n' )
-    ofile.close()    
+    ofile.write('Phase: {0:8s} \n'.format(mcpara.phase))
+    ofile.write(mcpara.evline + '\n')
+    ofile.close()
 
 def corrite(solist, mcpara, reftimes, solution, outvar, outcc):
     """ Write output file, set output time picks.
     """
     nsta = len(solist)
-    # set wpick    
+    # set wpick
     wpick = mcpara.wpick
     itmean = mean(reftimes)
     for i in range(nsta):
-        wt = itmean + solution[i,0]
+        wt = itmean + solution[i, 0]
         solist[i].sethdr(wpick, wt)
     t0_times = [sacdh.gethdr('t0') for sacdh in solist]
-    delay_times = [(solution[i,0]-(t0_times[i]-itmean)) for i in range(nsta)]
+    delay_times = [(solution[i, 0]-(t0_times[i]-itmean)) for i in range(nsta)]
 
     selist_LonLat, delay_times = WriteFileWithDelay(mcpara, solist, solution, outvar, outcc, t0_times, delay_times, itmean)
     WriteFileOriginal(mcpara, solist, solution, outvar, outcc, itmean)
     return selist_LonLat, delay_times
 
 def mccc(gsac, mcpara):
-    """ Run MCCC. 
+    """ Run MCCC.
     """
     selist = gsac.selist
     delist = gsac.delist
     # sort sacdh list by net.sta
-    stalist = [ sacdh.netsta for sacdh in selist ]
+    stalist = [sacdh.netsta for sacdh in selist]
     stainds = argsort(stalist)
-    solist = [ selist[i] for i in stainds ]
+    solist = [selist[i] for i in stainds]
     nsta = len(solist)
     ipick = mcpara.ipick
     wpick = mcpara.wpick
@@ -427,29 +431,29 @@ def mccc(gsac, mcpara):
 
 
 def eventListName(evlist='event.list', phase='S', isol='PDE'):
-    """ 
+    """
     Read evlist (either event.list file or gsac.event list) for hypocenter and origin time.
     Create output filename.
     """
-    eventfmt  = '{0:<6s} {1:4d} {2:2d} {3:2d} {4:2d} {5:2d} {6:5.2f} '
+    eventfmt = '{0:<6s} {1:4d} {2:2d} {3:2d} {4:2d} {5:2d} {6:5.2f} '
     eventfmt += '{7:9.3f} {8:9.3f} {9:6.1f} {10:4.1f} {11:4.1f} '
-    fnamefmt  = '{0!s:0>4}{1!s:0>2}{2!s:0>2}.{3!s:0>2}{4!s:0>2}{5!s:0>4}.mc{6:s}'
+    fnamefmt = '{0!s:0>4}{1!s:0>2}{2!s:0>2}.{3!s:0>2}{4!s:0>2}{5!s:0>4}.mc{6:s}'
     if type(evlist) == type(''):
         evhypo = open(evlist).readline().split()
-        elat, elon, dum, edep = [ float(v) for v in evhypo[:4] ]
-        sec, mb, mw = [ float(v) for v in evhypo[8:11] ]
-        iyr, jday, ihr, imin = [ int(v) for v in evhypo[4:8] ]
-        imon, iday = [ int(v) for v in evhypo[13:15] ]
+        elat, elon, dum, edep = [float(v) for v in evhypo[:4]]
+        sec, mb, mw = [float(v) for v in evhypo[8:11]]
+        iyr, jday, ihr, imin = [int(v) for v in evhypo[4:8]]
+        imon, iday = [int(v) for v in evhypo[13:15]]
     else:
         iyr, imon, iday, ihr, imin, sec, elat, elon, edep, mw = evlist
         mb = 0
     isec = int(round(sec*100))
     evline = eventfmt.format(isol, iyr, imon, iday, ihr, imin, sec, elat, elon, edep, mb, mw)
-    mcname = fnamefmt.format(iyr, imon, iday, ihr, imin, isec, phase.lower() )
+    mcname = fnamefmt.format(iyr, imon, iday, ihr, imin, isec, phase.lower())
     return evline, mcname
 
 def getWindow(stkdh, ipick, twhdrs, taperwidth=0.1):
-    """ Get timewindow and taperwindow from gsac.stkdh """    
+    """ Get timewindow and taperwindow from gsac.stkdh """
     tw0, tw1 = twhdrs
     t0 = stkdh.gethdr(ipick)
     th0 = stkdh.gethdr(tw0) - t0
@@ -464,8 +468,8 @@ def getParams(gsac, mcpara, opts=None):
     """
     nsta = len(gsac.saclist)
     if nsta < 5:
-        print ('\n Less than five stations - stop')
-        sys.exit()    
+        print('\n Less than five stations - stop')
+        sys.exit()
     # get window from gsac.stkdh
     if 'stkdh' in gsac.__dict__:
         timewindow, taperwindow = getWindow(gsac.stkdh, mcpara.ipick, mcpara.twhdrs, mcpara.taperwidth)
@@ -497,7 +501,7 @@ def getParams(gsac, mcpara, opts=None):
                 mdict[key] = odict[key]
     # check if params are complete
     if 'phase' not in mdict:
-        print ('\n No phase name given - stop')
+        print('\n No phase name given - stop')
         sys.exit()
     if 'timewindow' not in mdict:
         if 'window' in mdict and 'inset' in mdict:
@@ -508,7 +512,7 @@ def getParams(gsac, mcpara, opts=None):
             else:
                 mcpara.taperwindow = sacpkl.taperWindow(mcpara.timewindow, mcpara.taperwidth)
         else:
-            print ('No window and inset length give - stop')
+            print('No window and inset length give - stop')
             sys.exit()
     # get event info from either event.list or gsac
     if not os.path.isfile(mcpara.evlist):
@@ -520,7 +524,7 @@ def getParams(gsac, mcpara, opts=None):
     if mcpara.ofilename != 'mc':
         mcpara.mcname = mcpara.ofilename
     gsac.mcname = mcpara.mcname
-    
+
 def main():
     opts, ifiles = getOptions()
     mcpara = ttconfig.MCConfig()
@@ -528,12 +532,12 @@ def main():
 
     if opts.phase is None:
         phase = findPhase(ifiles[0])
-        print ('Found phase to be: ' + phase + '\n')
+        print('Found phase to be: ' + phase + '\n')
         mcpara.phase = phase
 
     opts.fstack = mcpara.fstack
     if opts.filemode == 'sac' and os.path.isfile(opts.fstack):
-        print ('Read array stack file: ' + opts.fstack )
+        print('Read array stack file: ' + opts.fstack)
         gsac.stkdh = sacpkl.SacDataHdrs(opts.fstack, opts.delta)
 
     getParams(gsac, mcpara, opts)
@@ -550,4 +554,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/src/pysmo/aimbat/algmccc.py
+++ b/src/pysmo/aimbat/algmccc.py
@@ -25,7 +25,7 @@ import os
 import sys
 from time import strftime, tzname
 from optparse import OptionParser
-from numpy import array, mean, dot, zeros, log, transpose, concatenate, exp, sum, std, shape, sqrt, argsort, identity 
+from numpy import array, mean, dot, zeros, log, transpose, concatenate, exp, sum, std, shape, sqrt, argsort, identity
 from pysmo.aimbat import ttconfig
 from pysmo.aimbat import qualsort
 from pysmo.aimbat import sacpickle as sacpkl
@@ -246,7 +246,7 @@ def corrnow(invmatrix, invdata):
     return invmodel
 
 def corrwgt(invmatrix, invdata, ccmatrix, resmatrix, wgtscheme='correlation', exwt=1000.0):
-    """ 
+    """
     Solve A * t = dt by weighted least-squares:
             t = inv(A'WA) * A' * W * dt
     W: n*(n-1)/2+1 by n*(n-1)/2+1 diagonal weighting matrix
@@ -394,7 +394,7 @@ def mccc(gsac, mcpara):
     out = 'Run MCCC: ipick={0:s} wpick={1:s} timewindow=[{2:.3f}, {3:.3f}] taperwindow={4:.3f} s '
     print(out.format(ipick, wpick, timewindow[0], timewindow[1], taperwindow))
     out = 'Cross-correlation module.function: {:s}.{:s} with a shift of {:d} samples.'
-    print(out.format(mcpara.xcorr_modu, mcpara.xcorr_func, mcpara.shift))
+    print(out.format(mcpara.xcorr_modu.__name__, mcpara.xcorr.__name__, mcpara.shift))
     print('Input: {0:d} traces. Output file: {1:s} '.format(nsta, mcpara.mcname))
     # read data
     windata, reftimes = corread(solist, ipick, timewindow, taperwindow, tapertype)
@@ -472,7 +472,8 @@ def getParams(gsac, mcpara, opts=None):
         sys.exit()
     # get window from gsac.stkdh
     if 'stkdh' in gsac.__dict__:
-        timewindow, taperwindow = getWindow(gsac.stkdh, mcpara.ipick, mcpara.twhdrs, mcpara.taperwidth)
+        timewindow, taperwindow = getWindow(gsac.stkdh, mcpara.ipick,
+                                            mcpara.twhdrs, mcpara.taperwidth)
         mcpara.timewindow = timewindow
         mcpara.taperwindow = taperwindow
 

--- a/src/pysmo/aimbat/ttconfig.py
+++ b/src/pysmo/aimbat/ttconfig.py
@@ -7,7 +7,8 @@
 # Copyright (c) 2009-2012 Xiaoting Lou
 #------------------------------------------------
 """
-Python module for setting up default parameters for SACPLOT (PlotPhase and PickPhase), ICCS, MCCC and QCTRL.
+Python module for setting up default parameters for SACPLOT (PlotPhase and
+PickPhase), ICCS, MCCC and QCTRL.
 Create parser for command line arguments and options.
 
 
@@ -21,6 +22,7 @@ Create parser for command line arguments and options.
 
 
 import os
+from importlib import import_module
 from configparser    import ConfigParser
 from optparse        import OptionParser
 
@@ -153,18 +155,23 @@ class CCConfig:
         self.shift = config.getint('iccs', 'shift')
         modu = config.get('iccs', 'xcorr_modu')
         func = config.get('iccs', 'xcorr_func')
-        cmd1a = 'from  {:s} import {:s}'.format(modu, func)
-        cmd1r = 'from .{:s} import {:s}'.format(modu, func)
-        cmd2 = 'self.xcorr = {:s}'.format(func)
+        #cmd1a = 'from  {:s} import {:s}'.format(modu, func)
+        #cmd1r = 'from .{:s} import {:s}'.format(modu, func)
+        #cmd2 = 'self.xcorr = {:s}'.format(func)
         # try importing fortran xcorr
         try:
-            exec(cmd1r)
-        except:
-            exec(cmd1a)
-        exec(cmd2)
-        print('Using {:s}.{:s} as cross-correlation method for ICCS'.format(modu, func))
-        self.xcorr_modu = modu
-        self.xcorr_func = func
+            xcorr_modu = import_module('pysmo.aimbat.xcorrf90')
+            xcorr_func = getattr(xcorr_modu, func)
+            #exec(cmd1r)
+        except ModuleNotFoundError:
+            xcorr_modu = import_module('pysmo.aimbat.xcorr')
+            xcorr_func = getattr(xcorr_modu, func)
+            #exec(cmd1a)
+        #exec(cmd2)
+        print('Using {:s}.{:s} as cross-correlation method for ICCS'.format(xcorr_modu.__name__, func))
+        self.xcorr = xcorr_func
+        self.xcorr_modu = xcorr_modu
+        self.xcorr_func = xcorr_func
 
 class MCConfig:
     """ Class for MCCC configuration.
@@ -193,17 +200,22 @@ class MCConfig:
         self.shift = config.getint('mccc', 'shift')
         modu = config.get('mccc', 'xcorr_modu')
         func = config.get('mccc', 'xcorr_func')
-        cmd1a = 'from  {:s} import {:s}'.format(modu, func)
-        cmd1r = 'from .{:s} import {:s}'.format(modu, func)
-        cmd2 = 'self.xcorr = {:s}'.format(func)
+        #cmd1a = 'from  {:s} import {:s}'.format(modu, func)
+        #cmd1r = 'from .{:s} import {:s}'.format(modu, func)
+        #cmd2 = 'self.xcorr = {:s}'.format(func)
         try:
-            exec(cmd1r)
-        except:
-            exec(cmd1a)
-        exec(cmd2)
+            xcorr_modu = import_module('pysmo.aimbat.xcorrf90')
+            xcorr_func = getattr(xcorr_modu, func)
+            #exec(cmd1r)
+        except ModuleNotFoundError:
+            xcorr_modu = import_module('pysmo.aimbat.xcorr')
+            xcorr_func = getattr(xcorr_modu, func)
+            #exec(cmd1a)
+        #exec(cmd2)
         print('Using {:s}.{:s} as cross-correlation method for MCCC'.format(modu, func))
-        self.xcorr_modu = modu
-        self.xcorr_func = func
+        self.xcorr = xcorr_func
+        self.xcorr_modu = xcorr_modu
+        self.xcorr_func = xcorr_func
 
 def getParser():
     """ Parse command line arguments and options. """

--- a/src/pysmo/aimbat/ttconfig.py
+++ b/src/pysmo/aimbat/ttconfig.py
@@ -153,25 +153,17 @@ class CCConfig:
         self.ichdrs = config.get('sachdrs', 'ichdrs').split()
         # Choose a xcorr module and function
         self.shift = config.getint('iccs', 'shift')
-        modu = config.get('iccs', 'xcorr_modu')
         func = config.get('iccs', 'xcorr_func')
-        #cmd1a = 'from  {:s} import {:s}'.format(modu, func)
-        #cmd1r = 'from .{:s} import {:s}'.format(modu, func)
-        #cmd2 = 'self.xcorr = {:s}'.format(func)
-        # try importing fortran xcorr
         try:
             xcorr_modu = import_module('pysmo.aimbat.xcorrf90')
             xcorr_func = getattr(xcorr_modu, func)
-            #exec(cmd1r)
         except ModuleNotFoundError:
             xcorr_modu = import_module('pysmo.aimbat.xcorr')
             xcorr_func = getattr(xcorr_modu, func)
-            #exec(cmd1a)
-        #exec(cmd2)
-        print('Using {:s}.{:s} as cross-correlation method for ICCS'.format(xcorr_modu.__name__, func))
+        print('Imported {:s} from {:s} as cross-correlation method for ICCS'
+              .format(xcorr_func.__name__, xcorr_modu.__name__))
         self.xcorr = xcorr_func
         self.xcorr_modu = xcorr_modu
-        self.xcorr_func = xcorr_func
 
 class MCConfig:
     """ Class for MCCC configuration.
@@ -196,26 +188,19 @@ class MCConfig:
         self.hdrsel = config.get('sachdrs', 'hdrsel')
         # SAC headers for MCCC time picks
         self.ipick, self.wpick = config.get('sachdrs', 'mchdrs').split()
-        # Choose a xcorr module and function
+        # Choose a xcorr function
         self.shift = config.getint('mccc', 'shift')
-        modu = config.get('mccc', 'xcorr_modu')
         func = config.get('mccc', 'xcorr_func')
-        #cmd1a = 'from  {:s} import {:s}'.format(modu, func)
-        #cmd1r = 'from .{:s} import {:s}'.format(modu, func)
-        #cmd2 = 'self.xcorr = {:s}'.format(func)
         try:
             xcorr_modu = import_module('pysmo.aimbat.xcorrf90')
             xcorr_func = getattr(xcorr_modu, func)
-            #exec(cmd1r)
         except ModuleNotFoundError:
             xcorr_modu = import_module('pysmo.aimbat.xcorr')
             xcorr_func = getattr(xcorr_modu, func)
-            #exec(cmd1a)
-        #exec(cmd2)
-        print('Using {:s}.{:s} as cross-correlation method for MCCC'.format(modu, func))
+        print('Imported {:s} from {:s} as cross-correlation method for MCCC'
+              .format(xcorr_func.__name__, xcorr_modu.__name__))
         self.xcorr = xcorr_func
         self.xcorr_modu = xcorr_modu
-        self.xcorr_func = xcorr_func
 
 def getParser():
     """ Parse command line arguments and options. """

--- a/src/pysmo/aimbat/ttconfig.py
+++ b/src/pysmo/aimbat/ttconfig.py
@@ -15,7 +15,7 @@ Create parser for command line arguments and options.
     Xiaoting Lou
 
 :license:
-    GNU General Public License, Version 3 (GPLv3) 
+    GNU General Public License, Version 3 (GPLv3)
     http://www.gnu.org/licenses/gpl.html
 """
 
@@ -26,12 +26,12 @@ from optparse        import OptionParser
 
 
 def getDefaults():
-    """ 
-    Get default parameters from a configuration file: ttdefaults.conf. 
+    """
+    Get default parameters from a configuration file: ttdefaults.conf.
     The file is searched in this order:
         (0) the current working directory
         (1) home directory
-        (2) environment variable TTCONFIG 
+        (2) environment variable TTCONFIG
         (3) the same directory as this program.
     """
     conf = 'TTCONFIG'
@@ -63,10 +63,10 @@ class PPConfig:
         self.hdrsel = config.get('sachdrs', 'hdrsel')
         self.qfactors = config.get('sachdrs', 'qfactors').split()
         self.qheaders = config.get('sachdrs', 'qheaders').split()
-        self.qweights = [ float(val)  for val in config.get('sachdrs', 'qweights').split() ]
+        self.qweights = [float(val)  for val in config.get('sachdrs', 'qweights').split()]
         # SAC plots
-        self.figsize = [ float(val)  for val in config.get('sacplot', 'figsize').split() ]
-        self.rectseis = [ float(val)  for val in config.get('sacplot', 'rectseis').split() ]
+        self.figsize = [float(val)  for val in config.get('sacplot', 'figsize').split()]
+        self.rectseis = [float(val)  for val in config.get('sacplot', 'rectseis').split()]
         self.colorwave = config.get('sacplot', 'colorwave')
         self.colorwavedel = config.get('sacplot', 'colorwavedel')
         self.colortwfill = config.get('sacplot', 'colortwfill')
@@ -81,14 +81,14 @@ class PPConfig:
         self.srate = config.getfloat('sacplot', 'srate')
         self.tapertype = config.get('signal', 'tapertype')
         self.taperwidth = config.getfloat('signal', 'taperwidth')
-        # SAC headers for filter 
+        # SAC headers for filter
         self.fhdrApply = config.get('signal', 'fhdrApply')
         self.fhdrBand = config.get('signal', 'fhdrBand')
         self.fhdrRevPass = config.get('signal', 'fhdrRevPass')
         self.fhdrLowFreq = config.get('signal', 'fhdrLowFreq')
         self.fhdrHighFreq = config.get('signal', 'fhdrHighFreq')
         self.fhdrOrder = config.get('signal', 'fhdrOrder')
-        # default values for filter 
+        # default values for filter
         self.fvalApply = config.getint('signal', 'fvalApply')
         self.fvalBand = config.get('signal', 'fvalBand')
         self.fvalRevPass = config.getint('signal', 'fvalRevPass')
@@ -110,7 +110,7 @@ class QCConfig:
         self.hdrsel = config.get('sachdrs', 'hdrsel')
         self.qfactors = config.get('sachdrs', 'qfactors').split()
         self.qheaders = config.get('sachdrs', 'qheaders').split()
-        self.qweights = [ float(val)  for val in config.get('sachdrs', 'qweights').split() ] 
+        self.qweights = [float(val)  for val in config.get('sachdrs', 'qweights').split()]
         # SAC headers for ICCS time picks
         self.ichdrs = config.get('sachdrs', 'ichdrs').split()
         # plots
@@ -146,7 +146,7 @@ class CCConfig:
         self.hdrsel = config.get('sachdrs', 'hdrsel')
         self.qfactors = config.get('sachdrs', 'qfactors').split()
         self.qheaders = config.get('sachdrs', 'qheaders').split()
-        self.qweights = [ float(val)  for val in config.get('sachdrs', 'qweights').split() ] 
+        self.qweights = [float(val)  for val in config.get('sachdrs', 'qweights').split()]
         # SAC headers for ICCS time picks
         self.ichdrs = config.get('sachdrs', 'ichdrs').split()
         # Choose a xcorr module and function
@@ -156,6 +156,7 @@ class CCConfig:
         cmd1a = 'from  {:s} import {:s}'.format(modu, func)
         cmd1r = 'from .{:s} import {:s}'.format(modu, func)
         cmd2 = 'self.xcorr = {:s}'.format(func)
+        # try importing fortran xcorr
         try:
             exec(cmd1r)
         except:
@@ -166,7 +167,7 @@ class CCConfig:
         self.xcorr_func = func
 
 class MCConfig:
-    """ Class for MCCC configuration. 
+    """ Class for MCCC configuration.
     """
     def __init__(self):
         defaults = getDefaults()
@@ -207,7 +208,7 @@ class MCConfig:
 def getParser():
     """ Parse command line arguments and options. """
     reltime = -1
-    fill = 0 
+    fill = 0
     ynorm = 2.0
     usage = "Usage: %prog [options] <sacfile(s) or a picklefile>"
     parser = OptionParser(usage=usage)
@@ -215,25 +216,27 @@ def getParser():
     parser.set_defaults(fill=fill)
     parser.set_defaults(ynorm=ynorm)
 
-    parser.add_option('-f', '--fill', dest='fill', type = 'int',
-        help='Fill/shade seismogram with positive (1) or negative (-1) signal. Default is none ({:d}).'.format(fill))
-    parser.add_option('-r', '--relative-time',  dest='reltime', type='int',
-        help='Relative time to a time pick header (t0-t9). Default is {:d}, None, use absolute time.'.format(reltime))
+    parser.add_option('-f', '--fill', dest='fill', type='int',
+                      help='Fill/shade seismogram with positive (1) or negative (-1) signal. '
+                      'Default is none ({:d}).'.format(fill))
+    parser.add_option('-r', '--relative-time', dest='reltime', type='int',
+                      help='Relative time to a time pick header (t0-t9). '
+                      'Default is {:d}, None, use absolute time.'.format(reltime))
     parser.add_option('-u', '--upylim', action="store_true", dest='upylim_on',
-        help='Update ylim every time of zooming in.')
+                      help='Update ylim every time of zooming in.')
     parser.add_option('-k', '--pick', action="store_true", dest='pick_on',
-        help='Plot time picks.')
+                      help='Plot time picks.')
     parser.add_option('-w', '--twin', action="store_true", dest='twin_on',
-        help='Plot time window.')
-    parser.add_option('-x', '--xlimit',  dest='xlimit', type='float', nargs=2, 
-        help='Left and right x-axis limit to plot.')
-    parser.add_option('-y', '--ynorm',  dest='ynorm', type='float',
-        help='Normalize ydata of seismograms. Effective only for positive number. Default is {:f}.'.format(ynorm))
+                      help='Plot time window.')
+    parser.add_option('-x', '--xlimit', dest='xlimit', type='float', nargs=2,
+                      help='Left and right x-axis limit to plot.')
+    parser.add_option('-y', '--ynorm', dest='ynorm', type='float',
+                      help='Normalize ydata of seismograms. Effective only for positive number. '
+                      'Default is {:f}.'.format(ynorm))
     parser.add_option('-Y', '--ynormtwin', action="store_true", dest='ynormtwin_on',
-        help='Normalize seismogram within time window.')
-    parser.add_option('-S', '--srate',  dest='srate', type='float',
-        help='Sampling rate to load SAC data. Default is None, use the original rate of first file.')
+                      help='Normalize seismogram within time window.')
+    parser.add_option('-S', '--srate', dest='srate', type='float',
+                      help='Sampling rate to load SAC data. '
+                      'Default is None, use the original rate of first file.')
 
     return parser
-
-

--- a/src/pysmo/aimbat/ttdefaults.conf
+++ b/src/pysmo/aimbat/ttdefaults.conf
@@ -48,7 +48,6 @@ qweights = 0.3333 0.3333 0.3333
 srate = -1 
 ### cross-correlation: full/fast/faster
 ### cross-correlation: full/fast/faster_polarity to avoid reverse polarity
-xcorr_modu = xcorrf90
 xcorr_func = xcorr_faster_polarity
 shift = 10
 maxiter = 10
@@ -68,7 +67,6 @@ fstack = fstack.sac
 srate = -1 
 ### output file: "$evdate".mc if mc
 ofilename = mc
-xcorr_modu = xcorrf90
 xcorr_func = xcorr_faster_polarity
 shift = 10
 extraweight = 1000.

--- a/src/pysmo/aimbat/xcorr.py
+++ b/src/pysmo/aimbat/xcorr.py
@@ -27,7 +27,7 @@ Output ccpol=1 if positive or ccpol=-1 if negative. xlou 03/2011
 from numpy import correlate, dot, argmax, argmin, sqrt
 
 def _xcorr(x, y, cmode='full'):
-    """ 
+    """
     Cross-correlation of two 1-D arrays using 'full' or 'same' mode.
         c[k] = sum_i x[i]*y[i+k]
     Full mode: indices of array c --> j=0:nx+ny-2 <-- k=ny-1:-nx+1:-1 (j=ny-1-k)
@@ -41,17 +41,17 @@ def _xcorr(x, y, cmode='full'):
     if ccmax >= -ccmin:
         ccpol = 1
         delay = len(y)-1-imax
-        ccmax =  ccmax / sqrt(dot(x,x)*dot(y,y))
+        ccmax = ccmax / sqrt(dot(x, x)*dot(y, y))
     else:
         ccpol = -1
         delay = len(y)-1-imin
-        ccmax = -ccmin / sqrt(dot(x,x)*dot(y,y))
+        ccmax = -ccmin / sqrt(dot(x, x)*dot(y, y))
     if cmode == 'same':
         delay -= (len(y)-1)/2
     return delay, ccmax, ccpol
 
 def _xcorr_polarity(x, y, cmode='full'):
-    """ 
+    """
     Cross-correlation of two 1-D arrays using 'full' or 'same' mode.
         c[k] = sum_i x[i]*y[i+k]
     Full mode: indices of array c --> j=0:nx+ny-2 <-- k=ny-1:-nx+1:-1 (j=ny-1-k)
@@ -65,20 +65,20 @@ def _xcorr_polarity(x, y, cmode='full'):
     ccmax = cc[imax]
     ccpol = 1
     delay = len(y)-1-imax
-    ccmax =  ccmax / sqrt(dot(x,x)*dot(y,y))
+    ccmax = ccmax / sqrt(dot(x, x)*dot(y, y))
     if cmode == 'same':
         delay -= (len(y)-1)/2
     return delay, ccmax, ccpol
 
 def xcorr_full(x, y, shift=1):
-    """ 
+    """
     Cross-correlation of two 1-D arrays using 'full' mode.
     Argument shift=1 is here only in order to make the same number of arguments for all xcorr functions.
     """
     return _xcorr(x, y, 'full')
 
 def xcorr_full_polarity(x, y, shift=1):
-    """ 
+    """
     Cross-correlation of two 1-D arrays using 'full' mode.
     Argument shift=1 is here only in order to make the same number of arguments for all xcorr functions.
     Not correct the polarity
@@ -86,14 +86,14 @@ def xcorr_full_polarity(x, y, shift=1):
     return _xcorr_polarity(x, y, 'full')
 
 def xcorr_same(x, y):
-    """ 
+    """
     Cross-correlation of two 1-D arrays using 'same' mode.
     """
     return _xcorr(x, y, 'same')
 
 def xcorr_select(x, y, lags):
-    """ 
-    Cross-correlation of two time series of the same length 
+    """
+    Cross-correlation of two time series of the same length
     for selected lag(shift) times
     """
     n = len(x)
@@ -110,15 +110,15 @@ def xcorr_select(x, y, lags):
     if ccmax >= -ccmin:
         ccpol = 1
         delay = lags[imax]
-        ccmax =  ccmax / sqrt(dot(x,x)*dot(y,y))
+        ccmax = ccmax / sqrt(dot(x, x)*dot(y, y))
     else:
         ccpol = -1
         delay = lags[imin]
-        ccmax = -ccmin / sqrt(dot(x,x)*dot(y,y))
+        ccmax = -ccmin / sqrt(dot(x, x)*dot(y, y))
     return delay, ccmax, ccpol
 
 def xcorr_fast(x, y, shift=10):
-    """ 
+    """
     Fast cross-correlation of two time series of the same length.
     One level of coarse shift by downsampling the signal.
     """
@@ -130,7 +130,7 @@ def xcorr_fast(x, y, shift=10):
     return delay, ccmax, ccpol
 
 def xcorr_faster(x, y, shift=10):
-    """ 
+    """
     Faster cross-correlation only for time lags around zero.
     """
     lags = list(range(-shift, shift+1, 1))
@@ -138,8 +138,8 @@ def xcorr_faster(x, y, shift=10):
     return delay, ccmax, ccpol
 
 def xcorr_select_polarity(x, y, lags):
-    """ 
-    Cross-correlation of two time series of the same length 
+    """
+    Cross-correlation of two time series of the same length
     for selected lag(shift) times
     Do not correct polarity
     """
@@ -154,11 +154,11 @@ def xcorr_select_polarity(x, y, lags):
     ccmax = cc[imax]
     ccpol = 1
     delay = lags[imax]
-    ccmax =  ccmax / sqrt(dot(x,x)*dot(y,y))
+    ccmax = ccmax / sqrt(dot(x, x)*dot(y, y))
     return delay, ccmax, ccpol
 
 def xcorr_fast_polarity(x, y, shift=10):
-    """ 
+    """
     Fast cross-correlation of two time series of the same length.
     One level of coarse shift by downsampling the signal.
     Do not correct polarity
@@ -171,7 +171,7 @@ def xcorr_fast_polarity(x, y, shift=10):
     return delay, ccmax, ccpol
 
 def xcorr_faster_polarity(x, y, shift=10):
-    """ 
+    """
     Faster cross-correlation only for time lags around zero.
     Do not correct polarity
     """


### PR DESCRIPTION
This PR makes fortran optional during the build process and while loading the cross-correlation module.

- always tries loading from the fortran module first
- module does not have to be declared in ttdefaults anymore