### PR TITLE
feat: add in-memory seismogram data cache

### DIFF
--- a/src/aimbat/_config.py
+++ b/src/aimbat/_config.py
@@ -4,7 +4,11 @@ from aimbat._lib._mixins import EventParametersValidatorMixin
 from aimbat.aimbat_types import PydanticNegativeTimedelta, PydanticPositiveTimedelta
 from pysmo.tools.iccs._defaults import ICCS_DEFAULTS
 from pydantic import Field, model_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import (
+    BaseSettings,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+)
 from pathlib import Path
 from typing import Literal, Self
 import numpy as np
@@ -211,12 +215,26 @@ def generate_settings_table_markdown() -> str:
     """Generate a markdown table of all AIMBAT default settings."""
     import json
 
+    class _DefaultsOnly(Settings):
+        """Settings subclass that ignores all external sources."""
+
+        @classmethod
+        def settings_customise_sources(
+            cls,
+            settings_cls: type[BaseSettings],
+            init_settings: PydanticBaseSettingsSource,
+            env_settings: PydanticBaseSettingsSource,
+            dotenv_settings: PydanticBaseSettingsSource,
+            file_secret_settings: PydanticBaseSettingsSource,
+        ) -> tuple[PydanticBaseSettingsSource, ...]:
+            return ()
+
     env_prefix = Settings.model_config.get("env_prefix", "").upper()
-    values: dict[str, str] = json.loads(settings.model_dump_json())
+    values: dict[str, str] = json.loads(_DefaultsOnly().model_dump_json())
 
     lines = [
         "| Environment Variable | Default | Description |",
-        "|---------------------|---------|-------------|",
+        "|----------------------|---------|-------------|",
     ]
 
     for name, value in values.items():

--- a/src/aimbat/core/_active_event.py
+++ b/src/aimbat/core/_active_event.py
@@ -1,11 +1,13 @@
 """Get and set the active event (i.e. the one being processed)."""
 
 # WARNING: Do not import other modules from `aimbat.core` here to avoid circular imports
+from aimbat.io import clear_seismogram_cache
 from aimbat.logger import logger
 from aimbat.models import AimbatEvent
 from aimbat.cli._common import HINTS
 from sqlmodel import Session, select
 from sqlalchemy.exc import NoResultFound
+from contextlib import suppress
 from uuid import UUID
 
 __all__ = [
@@ -81,6 +83,11 @@ def set_active_event(session: Session, event: AimbatEvent) -> None:
 
     logger.info(f"Activating {event=}")
 
+    with suppress(NoResultFound):
+        if event.id == get_active_event(session).id:
+            return
+
+    clear_seismogram_cache()
     event.active = True
     session.add(event)
     session.commit()

--- a/src/aimbat/io/_base.py
+++ b/src/aimbat/io/_base.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 
 
 __all__ = [
+    "clear_seismogram_cache",
     "create_event",
     "create_seismogram",
     "create_station",
@@ -23,12 +24,18 @@ __all__ = [
     "write_seismogram_data",
 ]
 
+_cache: dict[tuple[str, DataType], npt.NDArray[np.float64]] = {}
 
 station_creator = {DataType.SAC: sac.create_station_from_sacfile}
 event_creator = {DataType.SAC: sac.create_event_from_sacfile}
 seismogram_creator = {DataType.SAC: sac.create_seismogram_from_sacfile}
 seismogram_data_reader = {DataType.SAC: sac.read_seismogram_data_from_sacfile}
 seismogram_data_writer = {DataType.SAC: sac.write_seismogram_data_to_sacfile}
+
+
+def clear_seismogram_cache() -> None:
+    """Clear the in-memory seismogram data cache."""
+    _cache.clear()
 
 
 def create_station(datasource: str | PathLike, datatype: DataType) -> AimbatStation:
@@ -126,7 +133,11 @@ def read_seismogram_data(
     data_reader_fn = seismogram_data_reader.get(datatype)
     if data_reader_fn is None:
         raise NotImplementedError(f"I don't know how to read data of type {datatype}.")
-    return data_reader_fn(datasource)
+
+    key = (str(datasource), datatype)
+    if key not in _cache:
+        _cache[key] = data_reader_fn(datasource)
+    return _cache[key]
 
 
 def write_seismogram_data(
@@ -153,3 +164,4 @@ def write_seismogram_data(
             f"I don't know how to write data to file of type {datatype}"
         )
     data_writer_fn(datasource, data)
+    _cache.pop((str(datasource), datatype), None)

--- a/tests/integration/test_active_event.py
+++ b/tests/integration/test_active_event.py
@@ -2,6 +2,7 @@
 
 import pytest
 import uuid
+from unittest.mock import patch
 from aimbat.core import set_active_event, set_active_event_by_id, get_active_event
 from aimbat.models import AimbatEvent
 from sqlmodel import Session, select
@@ -96,6 +97,35 @@ class TestActiveEvent:
 
         with pytest.raises(ValueError):
             set_active_event_by_id(session, uuid.uuid4())
+
+    def test_set_same_event_does_not_clear_cache(self, session: Session) -> None:
+        """Verifies that re-activating the already-active event does not clear the cache.
+
+        Args:
+            session: The database session.
+        """
+        active_event = get_active_event(session)
+
+        with patch("aimbat.core._active_event.clear_seismogram_cache") as mock_clear:
+            set_active_event(session, active_event)
+            mock_clear.assert_not_called()
+
+    def test_set_different_event_clears_cache(self, session: Session) -> None:
+        """Verifies that switching to a different event clears the cache.
+
+        Args:
+            session: The database session.
+        """
+        active_event = get_active_event(session)
+        other_event = next(
+            e
+            for e in session.exec(select(AimbatEvent)).all()
+            if e.id != active_event.id
+        )
+
+        with patch("aimbat.core._active_event.clear_seismogram_cache") as mock_clear:
+            set_active_event(session, other_event)
+            mock_clear.assert_called_once()
 
     def test_get_active_event_no_active(self, session: Session) -> None:
         """Verifies that `get_active_event` returns None if no event is marked as active.

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -5,7 +5,13 @@ from pathlib import Path
 from typing import Any
 import pytest
 from rich.console import Console
-from aimbat._config import Settings, settings, print_settings_table, cli_settings_list
+from aimbat._config import (
+    Settings,
+    settings,
+    print_settings_table,
+    cli_settings_list,
+    generate_settings_table_markdown,
+)
 
 
 def _capture_pretty(monkeypatch: pytest.MonkeyPatch) -> str:
@@ -191,6 +197,51 @@ class TestPrintSettingsTablePretty:
         """
         output = _capture_pretty(monkeypatch)
         assert "AIMBAT_" in output
+
+
+class TestGenerateSettingsTableMarkdown:
+    """Tests for generate_settings_table_markdown."""
+
+    def test_returns_string(self) -> None:
+        """Verifies the function returns a string."""
+        assert isinstance(generate_settings_table_markdown(), str)
+
+    def test_contains_table_header(self) -> None:
+        """Verifies the output contains the markdown table header."""
+        output = generate_settings_table_markdown()
+        assert "| Environment Variable |" in output
+        assert "| Default |" in output
+        assert "| Description |" in output
+
+    def test_contains_all_env_var_names(self) -> None:
+        """Verifies that every setting appears as an AIMBAT_ environment variable."""
+        import json
+
+        output = generate_settings_table_markdown()
+        for name in json.loads(Settings().model_dump_json()):
+            assert f"AIMBAT_{name.upper()}" in output
+
+    def test_uses_true_defaults_not_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Verifies that env var overrides do not affect the generated table."""
+        monkeypatch.setenv("AIMBAT_LOG_LEVEL", "DEBUG")
+        output = generate_settings_table_markdown()
+        # Default is INFO; DEBUG must not appear as a value
+        lines = [li for li in output.splitlines() if "AIMBAT_LOG_LEVEL" in li]
+        assert len(lines) == 1
+        assert "`INFO`" in lines[0]
+        assert "`DEBUG`" not in lines[0]
+
+    def test_pipe_in_description_is_escaped(self) -> None:
+        """Verifies that pipe characters in descriptions are escaped."""
+        output = generate_settings_table_markdown()
+        # Split into rows and check no unescaped | appears inside a cell
+        for line in output.splitlines():
+            if not line.startswith("|"):
+                continue
+            # Strip the leading/trailing pipes and split on |
+            # Each cell should not contain a raw (unescaped) |
+            inner = line[1:-1]  # remove first and last |
+            assert "\\|" not in inner or inner.count("|") == inner.count("\\|")
 
 
 class TestCliSettingsList:


### PR DESCRIPTION
Cache seismogram data in memory on read, keyed by source path and datatype. The cache is cleared when the active event changes, so it effectively holds only the active event's data at any given time. Re-activating the already-active event is a no-op (cache preserved).

Also fixes set_active_event to compare events by id rather than identity, and generates the settings docs table from true field defaults rather than the env-influenced module-level settings instance.

<!-- readthedocs-preview aimbat start -->
----
📚 Documentation preview 📚: https://aimbat--220.org.readthedocs.build/en/220/

<!-- readthedocs-preview aimbat end -->