### PR TITLE
fix: set explicit permissions on workflow-calling jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,4 +12,6 @@ on:
 jobs:
   build:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: read
     uses: pysmo/.github/.github/workflows/build.yml@main

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -14,6 +14,8 @@ concurrency:
 
 jobs:
   prepare:
+    permissions:
+      contents: write
     uses: pysmo/.github/.github/workflows/release-prep.yml@main
     with:
       version: ${{ inputs.version }}


### PR DESCRIPTION
CodeQL flagged \`build.yml\` and \`release-prep.yml\` for not limiting \`GITHUB_TOKEN\` permissions. Jobs that call a reusable workflow via \`uses:\` need their own explicit permissions block too, since it caps what the called workflow's own permissions can grant.

Same fix applied to \`pysmo\` and \`pysmo/.github\`.

<!-- readthedocs-preview aimbat start -->
----
📚 Documentation preview 📚: https://aimbat--239.org.readthedocs.build/en/239/

<!-- readthedocs-preview aimbat end -->