### PR TITLE
fix: refresh project table after Tools-menu parameter changes

### DIFF
--- a/src/aimbat/_tui/app.py
+++ b/src/aimbat/_tui/app.py
@@ -875,10 +875,7 @@ class AimbatTUI(App[None]):
         # suspend() is synchronous, so the staleness poller cannot fire
         # between the session commit and this assignment.
         self._bound_iccs.created_at = Timestamp.now("UTC")
-        self.query_one(SeismogramPanel).refresh_data(
-            self._current_event_id, self._bound_iccs
-        )
-        self._refresh_event_bar()
+        self.refresh_all()
         self.notify("Done", timeout=2)
 
     def action_open_align(self) -> None:

--- a/src/aimbat/core/_event.py
+++ b/src/aimbat/core/_event.py
@@ -356,6 +356,7 @@ def set_event_parameter(
     parameters_hash = compute_parameters_hash(event)
     if not sync_from_matching_hash(session, parameters_hash):
         clear_mccc_quality(session, event)
+    session.commit()
 
 
 def dump_event_parameter_table(

--- a/src/aimbat/core/_seismogram.py
+++ b/src/aimbat/core/_seismogram.py
@@ -171,6 +171,7 @@ def reset_seismogram_parameters(session: Session, seismogram_id: UUID) -> None:
     parameters_hash = compute_parameters_hash(seismogram.event)
     if not sync_from_matching_hash(session, parameters_hash):
         clear_mccc_quality(session, seismogram.event)
+    session.commit()
 
 
 @overload
@@ -246,6 +247,7 @@ def set_seismogram_parameter(
     parameters_hash = compute_parameters_hash(seismogram.event)
     if not sync_from_matching_hash(session, parameters_hash):
         clear_mccc_quality(session, seismogram.event)
+    session.commit()
 
 
 def get_selected_seismograms(

--- a/tests/integration/core/test_event.py
+++ b/tests/integration/core/test_event.py
@@ -4,6 +4,7 @@ import uuid
 
 import pytest
 from pandas import Timedelta
+from sqlalchemy import Engine
 from sqlalchemy.exc import NoResultFound
 from sqlmodel import Session, select
 
@@ -200,6 +201,35 @@ class TestSetEventParameter:
                 Timedelta(seconds=10000),
                 validate_iccs=True,
             )
+
+    def test_set_parameter_persists_across_sessions(
+        self, loaded_engine: Engine
+    ) -> None:
+        """Verifies a change survives the session it was made in being closed.
+
+        Callers (TUI, CLI) always call `set_event_parameter` inside a
+        `with Session(engine) as session:` block and never commit
+        themselves, so the write must be durable by the time that session
+        closes — whether via this function's own commit or one it triggers
+        indirectly (e.g. `clear_mccc_quality`). Guards against the change
+        (and the `last_modified` DB trigger it fires) being silently rolled
+        back on session close.
+        """
+        with Session(loaded_engine) as session:
+            event = session.exec(select(AimbatEvent)).first()
+            assert event is not None
+            event_id = event.id
+            assert event.last_modified is None
+            new_value = Timedelta(seconds=20)
+            set_event_parameter(
+                session, event_id, EventParameter.WINDOW_POST, new_value
+            )
+
+        with Session(loaded_engine) as session:
+            event = session.get(AimbatEvent, event_id)
+            assert event is not None
+            assert event.parameters.window_post == new_value
+            assert event.last_modified is not None
 
 
 # ===================================================================

--- a/tests/integration/core/test_seismogram.py
+++ b/tests/integration/core/test_seismogram.py
@@ -4,6 +4,7 @@ import uuid
 
 import pytest
 from matplotlib.figure import Figure
+from sqlalchemy import Engine
 from sqlalchemy.exc import NoResultFound
 from sqlmodel import Session, select
 
@@ -125,6 +126,35 @@ class TestSetSeismogramParameter:
                 loaded_session, uuid.uuid4(), SeismogramParameter.FLIP, True
             )
 
+    def test_set_parameter_persists_across_sessions(
+        self, loaded_engine: Engine
+    ) -> None:
+        """Verifies a change survives the session it was made in being closed.
+
+        Callers (TUI, CLI) always call `set_seismogram_parameter` inside a
+        `with Session(engine) as session:` block and never commit
+        themselves, so the write must be durable by the time that session
+        closes — whether via this function's own commit or one it triggers
+        indirectly (e.g. `clear_mccc_quality`). Guards against the change
+        being silently rolled back on session close.
+        """
+        with Session(loaded_engine) as session:
+            seismogram = session.exec(select(AimbatSeismogram)).first()
+            assert seismogram is not None
+            seismogram_id = seismogram.id
+            original = getattr(seismogram.parameters, SeismogramParameter.SELECT)
+            set_seismogram_parameter(
+                session, seismogram_id, SeismogramParameter.SELECT, not original
+            )
+
+        with Session(loaded_engine) as session:
+            seismogram = session.get(AimbatSeismogram, seismogram_id)
+            assert seismogram is not None
+            assert (
+                getattr(seismogram.parameters, SeismogramParameter.SELECT)
+                is not original
+            )
+
 
 class TestResetSeismogramParameters:
     """Tests for resetting seismogram parameters to their defaults."""
@@ -162,6 +192,36 @@ class TestResetSeismogramParameters:
         """
         with pytest.raises(NoResultFound):
             reset_seismogram_parameters(loaded_session, uuid.uuid4())
+
+    def test_reset_parameters_persists_across_sessions(
+        self, loaded_engine: Engine
+    ) -> None:
+        """Verifies a reset survives the session it was made in being closed.
+
+        Callers always call `reset_seismogram_parameters` inside a
+        `with Session(engine) as session:` block and never commit
+        themselves, so the write must be durable by the time that session
+        closes — whether via this function's own commit or one it triggers
+        indirectly (e.g. `clear_mccc_quality`). Guards against the reset
+        being silently rolled back on session close.
+        """
+        with Session(loaded_engine) as session:
+            seismogram = session.exec(select(AimbatSeismogram)).first()
+            assert seismogram is not None
+            seismogram_id = seismogram.id
+            set_seismogram_parameter(
+                session, seismogram_id, SeismogramParameter.FLIP, True
+            )
+            reset_seismogram_parameters(session, seismogram_id)
+
+        with Session(loaded_engine) as session:
+            seismogram = session.get(AimbatSeismogram, seismogram_id)
+            assert seismogram is not None
+            defaults = AimbatSeismogramParametersBase()
+            assert (
+                getattr(seismogram.parameters, SeismogramParameter.FLIP)
+                == defaults.flip
+            )
 
 
 class TestGetSelectedSeismograms:

--- a/uv.lock
+++ b/uv.lock
@@ -2019,8 +2019,8 @@ wheels = [
 
 [[package]]
 name = "pysmo"
-version = "1.0.0.dev82+g53e5322ea"
-source = { git = "https://github.com/pysmo/pysmo?rev=master#53e5322ea31e4c5870b98a27f9268859055f4846" }
+version = "1.0.0.dev90+gfbb842968"
+source = { git = "https://github.com/pysmo/pysmo?rev=master#fbb8429684d9aa4587dfd3cfadc4de74f9f855c9" }
 dependencies = [
     { name = "annotated-types" },
     { name = "attrs" },


### PR DESCRIPTION
The Tools-menu handler (filter/pick/timewindow) only refreshed the event bar and seismogram panel, never the Project tab's events table, so last_modified appeared stale after use even though the underlying write was fine. Use refresh_all() there, matching the pattern already used after ICCS/MCCC runs.

Also add explicit session.commit() to set_event_parameter, set_seismogram_parameter and reset_seismogram_parameters for consistency with every other mutator in core/ — these previously relied on an incidental commit inside clear_mccc_quality/ sync_from_matching_hash, which is fragile even though it isn't what caused this bug.

Bump pysmo via make upgrade.

<!-- readthedocs-preview aimbat start -->
----
📚 Documentation preview 📚: https://aimbat--241.org.readthedocs.build/en/241/

<!-- readthedocs-preview aimbat end -->