### PR TITLE
fix: roll back session after failed automatic snapshot

### DIFF
--- a/src/aimbat/_cli/data.py
+++ b/src/aimbat/_cli/data.py
@@ -146,7 +146,10 @@ def _create_snapshots_for_touched_events(
             # itself wasn't added. Warn and move on to the next event rather
             # than raising, so one event's snapshot failure (e.g. an
             # unexpected quality-data shape) can't suppress the baseline for
-            # an unrelated event touched in the same call.
+            # an unrelated event touched in the same call. A failed commit
+            # leaves the session unusable until rolled back, which would
+            # otherwise make every subsequent event's snapshot fail too.
+            session.rollback()
             logger.warning(
                 f"Failed to create automatic snapshot for event {event_id}: {e}"
             )

--- a/tests/functional/test_cli_basic_ops.py
+++ b/tests/functional/test_cli_basic_ops.py
@@ -123,6 +123,63 @@ class TestDataManagement:
             expected_comment = f"Added {n} seismogram{'' if n == 1 else 's'}"
             assert snap["comment"] == expected_comment
 
+    def test_add_data_snapshot_failure_does_not_cascade(
+        self,
+        patched_engine: Engine,
+        multi_event_data: Sequence[Path],
+        cli: Callable[[str], None],
+        cli_json: Callable[[str], list | dict],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """One event's automatic snapshot failing must not knock out the rest.
+
+        Regression test: a failed `create_snapshot` call leaves the session
+        unusable until rolled back. If `_create_snapshots_for_touched_events`
+        doesn't roll back after catching the exception, every event
+        processed after the failing one silently fails too, even though
+        nothing is wrong with them.
+        """
+        from sqlmodel import Session
+
+        import aimbat.core as core
+        from aimbat.models import AimbatEvent
+
+        real_create_snapshot = core.create_snapshot
+        calls = {"n": 0}
+
+        def flaky_create_snapshot(
+            session: Session,
+            event: AimbatEvent,
+            comment: str | None = None,
+            **kwargs: object,
+        ) -> None:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                # Force a genuine flush failure inside create_snapshot's own
+                # commit by queuing a row that violates the unique constraint
+                # on AimbatEvent.time, rather than raising before any DB
+                # interaction happens.
+                session.add(
+                    AimbatEvent(time=event.time, latitude=0.0, longitude=0.0, depth=0.0)
+                )
+            return real_create_snapshot(session, event, comment=comment, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(core, "create_snapshot", flaky_create_snapshot)
+
+        files = " ".join(f.as_posix() for f in multi_event_data)
+        cli(f"data add {files} --no-progress")
+
+        events = cli_json("event dump")
+        assert isinstance(events, list)
+        assert len(events) > 1, "fixture should touch more than one event"
+
+        snapshot_data = cli_json("snapshot dump")
+        assert isinstance(snapshot_data, dict)
+        snapshots = snapshot_data["snapshots"]
+        assert len(snapshots) == len(events) - 1, (
+            "only the first (failing) event's snapshot should be missing"
+        )
+
     def test_add_data_singular_seismogram_comment(
         self,
         patched_engine: Engine,

--- a/uv.lock
+++ b/uv.lock
@@ -532,11 +532,11 @@ wheels = [
 
 [[package]]
 name = "deepmerge"
-version = "2.1.0"
+version = "3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2a/78/6e9e20106224083cfb817d2d3c26e80e72258d617b616721a169b87081e0/deepmerge-2.1.0.tar.gz", hash = "sha256:07ca7a7b8935df596c512fa8161877c0487ac61f691c07766e7d71d2b23bdd2f", size = 21449, upload-time = "2026-06-22T05:46:07.669Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/6c/9f4577a36d5f463a3a3f8322bd65d33e1a1a6b6ba1d692a5ebc3cba19015/deepmerge-3.0.tar.gz", hash = "sha256:14ed69f063de64b7743985c732ccff5d6c34ff4560946e7fbfd99086b853b9ce", size = 22279, upload-time = "2026-08-17T05:50:53.161Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/25/2a75b47cb057b1e164c604fb81ab690a6cdb5e2260ce651194eae90f64a3/deepmerge-2.1.0-py3-none-any.whl", hash = "sha256:8f148339a91d680a75ecb74ade235d9e759a93df373a0b04e9d31c8666cfeb75", size = 14345, upload-time = "2026-06-22T05:46:06.742Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/d7/7f19bedd30b90b72865aeec3a29127bed6dee6c9ef0324bb5b4d424bb0e3/deepmerge-3.0-py3-none-any.whl", hash = "sha256:c8541c3e186dc88d19a5513ad3a0b2d0b22beaa780969fc0c13b995a64265365", size = 14855, upload-time = "2026-08-17T05:50:52.218Z" },
 ]
 
 [[package]]
@@ -1930,11 +1930,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.20.0"
+version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
A failed create_snapshot() call left the session unusable, silently cascading the failure to every other event's automatic snapshot in the same data add call.

<!-- readthedocs-preview aimbat start -->
----
📚 Documentation preview 📚: https://aimbat--246.org.readthedocs.build/en/246/

<!-- readthedocs-preview aimbat end -->