### PR TITLE
feat(tui): table-aware footer, causal toggle, and station dimming

### DIFF
--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -121,22 +121,26 @@ without leaving the terminal.
 │ │  ...                                                         │ │
 │ └──────────────────────────────────────────────────────────────┘ │
 ├─────────────────────────────────────────────────────────────────┤
-│ e Events  d Add Data  a Align  t Tools  p Parameters  ...  q Quit│  ← footer
+│ i Add Data  p Parameters  t Tools  a Align  n New Snapshot  q Quit│ ← footer
 └─────────────────────────────────────────────────────────────────┘
 ```
 
 The **event bar** shows the event currently selected for processing and the
 ICCS status (`● ICCS ready` / `○ no ICCS`).
 
-The **footer** lists the available key bindings. Actions that require an event
-to be selected (Align, Tools, Parameters, New Snapshot) only appear once one
-is chosen.
+The **footer** is both project-state- and table-aware. Actions that require an
+event to be selected (Align, Tools, Parameters, New Snapshot) only appear once
+one is chosen, and several only appear on the tab (or table) they apply to —
+see [Global key bindings](#global-key-bindings) below. When a table row has
+keyboard focus, that row's own actions (normally reached via `Enter`) also
+appear directly in the footer as one-key shortcuts — see
+[Row actions](#row-actions).
 
 #### Tabs
 
 The TUI has three tabs:
 
-- **Project** — two tables side by side: the events in the project and the stations. Pressing `Enter` on an event row lets you select it, mark it completed, view its seismograms, or delete it.
+- **Project** — two tables side by side: the events in the project and the stations. Focus the events table and press its hotkey, or press `Enter` to open the row's action menu, to select it, mark it completed, view its seismograms, or delete it.
 - **Live data** — the seismogram table for the currently selected event. "Live" means the table always reflects the current in-memory ICCS state: picks, CC norms, and select/flip flags update immediately as you run alignment or change parameters, without any manual refresh. See [The ICCS Stack](iccs-stack.md) for a detailed explanation.
 - **Snapshots** — a list of saved parameter snapshots for the selected event with a quality summary panel.
 
@@ -148,67 +152,84 @@ Switch tabs with `H` / `L` (vim-style) or with the mouse. All tables support:
 |-----|--------|
 | `j` / `↓` | Move down |
 | `k` / `↑` | Move up |
+| `h` / `l` | Scroll left / right (wide tables) |
 | `g` / `G` | Jump to top / bottom |
 | `Enter` | Open row action menu |
 
 #### Row actions
 
-Pressing `Enter` on any table row opens a context menu. Available actions depend on the tab:
+Every row action is reachable two ways: press its key directly once the row's
+table has keyboard focus (it appears in the footer for as long as that table
+is focused), or press `Enter` on the row to open the same actions as a
+context menu — useful for mouse users, or when the key isn't top of mind.
+Available actions depend on the tab:
 
 **Project — Events table:**
 
-| Action | Description |
-|--------|-------------|
-| Select event | Make this the active event for processing |
-| Toggle completed | Mark or unmark the event as completed |
-| View seismograms | Switch to the Live data tab filtered to this event |
-| Delete event | Remove the event and its seismograms from the project |
+| Key | Action | Description |
+|-----|--------|-------------|
+| `s` | Select event | Make this the active event for processing |
+| `m` | Toggle completed | Mark or unmark the event as completed |
+| `v` | View seismograms | Switch to the Live data tab filtered to this event |
+| `d` | Delete event | Remove the event and its seismograms from the project |
 
 **Project — Stations table:**
 
-| Action | Description |
-|--------|-------------|
-| View seismograms | Switch to the Live data tab filtered to this station |
-| Delete station | Remove the station from the project |
+| Key | Action | Description |
+|-----|--------|-------------|
+| `v` | View seismograms | Switch to the Live data tab filtered to this station |
+| `d` | Delete station | Remove the station from the project |
 
 **Live data — Seismograms table:**
 
-| Action | Description |
-|--------|-------------|
-| Toggle select | Include or exclude this seismogram from the ICCS stack |
-| Toggle flip | Multiply the seismogram's data by −1 to correct polarity |
-| Reset parameters | Restore all per-seismogram parameters to their defaults |
-| Delete seismogram | Remove the seismogram from the project |
+| Key | Action | Description |
+|-----|--------|-------------|
+| `s` | Toggle select | Include or exclude this seismogram from the ICCS stack |
+| `f` | Toggle flip | Multiply the seismogram's data by −1 to correct polarity |
+| `u` | Reset seismogram | Restore all per-seismogram parameters to their defaults |
+| `d` | Delete seismogram | Remove the seismogram from the project |
 
 **Snapshots — Snapshots table:**
 
-| Action | Description |
-|--------|-------------|
-| Show details | Display the event-level parameters saved in the snapshot |
-| Preview stack | Open the ICCS stack plot built from the snapshot's parameters |
-| Preview matrix image | Open the matrix image built from the snapshot's parameters |
-| Save results to JSON | Export per-seismogram picks and MCCC metrics to a JSON file |
-| Rollback to this snapshot | Restore the snapshot's parameters as the current live values |
-| Delete snapshot | Permanently remove the snapshot |
+| Key | Action | Description |
+|-----|--------|-------------|
+| `v` | Show details | Display the event-level parameters saved in the snapshot |
+| `s` | Preview stack | Open the ICCS stack plot built from the snapshot's parameters |
+| `x` | Preview matrix image | Open the matrix image built from the snapshot's parameters |
+| `w` | Save results to JSON | Export per-seismogram picks and MCCC metrics to a JSON file |
+| `b` | Rollback to this snapshot | Restore the snapshot's parameters as the current live values |
+| `d` | Delete snapshot | Permanently remove the snapshot |
 
-Both preview options support `c` (toggle context waveforms) and `a` (include
-all seismograms) key bindings inside the action menu before the plot opens.
+The same key means the same thing on every table it appears on (`d` always
+deletes, `v` always means "look at this in more detail", `s` is the tab's
+main/default action), so once you've learned one table's hotkeys the others
+are largely familiar. The direct hotkey for **Preview stack**/**Preview
+matrix image** uses the action menu's default toggle values (context
+waveforms on, all seismograms off); to use non-default values, open the
+action menu with `Enter` and toggle `c`/`a` there before selecting the action.
 See [Snapshots](snapshots.md) for a description of each action and the format
 of the exported results file.
 
 #### Global key bindings
 
-| Key | Action |
-|-----|--------|
-| `e` | Open event switcher |
-| `a` | Run alignment (ICCS or MCCC) |
-| `t` | Open interactive parameter tools (phase pick, time window, min CC, bandpass filter) |
-| `p` | Edit processing parameters |
-| `n` | Create a new snapshot |
-| `d` | Add data files to the project |
-| `r` | Refresh all panels |
-| `c` | Toggle colour theme |
-| `q` | Quit |
+| Key | Action | Scope |
+|-----|--------|-------|
+| `i` | Add data files to the project | Project tab |
+| `p` | Edit processing parameters | Live data tab, or Project tab with the Events table focused |
+| `t` | Open interactive parameter tools (phase pick, time window, min CC, bandpass filter) | Live data tab |
+| `a` | Run alignment (ICCS or MCCC) | Live data tab |
+| `n` | Create a new snapshot | Live data tab |
+| `r` | Refresh all panels | Global |
+| `c` | Toggle colour theme | Global |
+| `q` | Quit | Global |
+
+The interactive tools modal (`t`) additionally supports `c` (toggle context
+waveforms) and `a` (include all seismograms) for every tool, and `z`
+(zero-phase instead of causal filtering) for the three tools that support it
+(phase pick, time window, min CC). The alignment modal (`a`) supports `f`
+(autoflip) and `s` (autoselect) for ICCS, and `a` (include all seismograms)
+for MCCC. All are toggled inside their respective modal before running the
+tool.
 
 #### ICCS lifecycle in the TUI
 

--- a/src/aimbat/_cli/common/_parameters.py
+++ b/src/aimbat/_cli/common/_parameters.py
@@ -26,6 +26,7 @@ __all__ = [
     "use_event_parameter",
     "use_matrix_image",
     "causal",
+    "CAUSAL_DEFAULTS",
     "open_in_editor",
     "DebugParameter",
     "EventDebugParameters",
@@ -203,6 +204,21 @@ def causal() -> Parameter:
         help="Use causal (single-pass) instead of zero-phase filtering.",
         negative="--zero-phase",
     )
+
+
+CAUSAL_DEFAULTS: dict[str, bool] = {
+    "phase": True,
+    "window": False,
+    "cc": False,
+}
+"""Default causal/zero-phase setting per `tool` subcommand/TUI tool id.
+
+Single source of truth for `_cli/tool.py`'s three `causal()` parameter
+defaults and the TUI's equivalent per-tool default (`InteractiveToolsModal`
+in `_tui/modals.py`). These three values previously had to be updated by
+hand in two places at once when pysmo changed one of its own per-function
+defaults - this constant removes that duplication.
+"""
 
 
 # -----------------------------------------------------------------------

--- a/src/aimbat/_cli/tool.py
+++ b/src/aimbat/_cli/tool.py
@@ -12,6 +12,7 @@ from uuid import UUID
 from cyclopts import App
 
 from .common import (
+    CAUSAL_DEFAULTS,
     DebugParameter,
     IccsPlotParameters,
     causal,
@@ -65,7 +66,7 @@ def cli_update_phase_pick(
     *,
     iccs_plot_parameters: IccsPlotParameters = IccsPlotParameters(),
     use_matrix_image: Annotated[bool, use_matrix_image()] = False,
-    causal: Annotated[bool, causal()] = True,
+    causal: Annotated[bool, causal()] = CAUSAL_DEFAULTS["phase"],
     _: DebugParameter = DebugParameter(),
 ) -> None:
     """Interactively pick a new phase arrival time (t1) for an event.
@@ -100,7 +101,7 @@ def cli_pick_timewindow(
     *,
     iccs_plot_parameters: IccsPlotParameters = IccsPlotParameters(),
     use_matrix_image: Annotated[bool, use_matrix_image()] = False,
-    causal: Annotated[bool, causal()] = False,
+    causal: Annotated[bool, causal()] = CAUSAL_DEFAULTS["window"],
     _: DebugParameter = DebugParameter(),
 ) -> None:
     """Interactively pick a new cross-correlation time window for an event.
@@ -137,7 +138,7 @@ def cli_pick_min_cc(
     *,
     iccs_plot_parameters: IccsPlotParameters = IccsPlotParameters(),
     use_matrix_image: Annotated[bool, use_matrix_image()] = True,
-    causal: Annotated[bool, causal()] = False,
+    causal: Annotated[bool, causal()] = CAUSAL_DEFAULTS["cc"],
     _: DebugParameter = DebugParameter(),
 ) -> None:
     """Interactively pick a new minimum cross-correlation for auto-selection.

--- a/src/aimbat/_tui/_panels.py
+++ b/src/aimbat/_tui/_panels.py
@@ -5,13 +5,16 @@ from __future__ import annotations
 import uuid
 from collections.abc import Callable, Sequence
 from contextlib import suppress
-from typing import Any, Literal
+from dataclasses import dataclass
+from typing import Any, ClassVar, Literal
 
 from pydantic import BaseModel
+from rich.text import Text
 from sqlalchemy.exc import NoResultFound, SQLAlchemyError
-from sqlmodel import Session
+from sqlmodel import Session, select
 from textual import on
 from textual.app import ComposeResult
+from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
 from textual.css.query import NoMatches
 from textual.message import Message
@@ -35,6 +38,7 @@ from aimbat.db import engine
 from aimbat.models import (
     AimbatEvent,
     AimbatEventRead,
+    AimbatSeismogram,
     AimbatSeismogramRead,
     AimbatSnapshotRead,
     AimbatStationRead,
@@ -53,23 +57,48 @@ _STATION_TABLE_EXCLUDE: set[str] = {"event_count"}
 _SEISMOGRAM_TABLE_EXCLUDE: set[str] = {"event_id", "short_event_id"}
 _SNAPSHOT_TABLE_EXCLUDE: set[str] = {"event_id", "short_event_id"}
 
-# Extend this dict to add new per-row actions to any tab.
-_TAB_ROW_ACTIONS: dict[str, list[tuple[str, str]]] = {
+
+@dataclass(frozen=True)
+class RowAction:
+    """One row-level action: a menu entry and, when its table has focus, a footer hotkey."""
+
+    id: str
+    """Action identifier, dispatched via `RowActionChosen`/`ActionChosen`."""
+
+    label: str
+    """Display label shown in the Enter-triggered action menu."""
+
+    key: str
+    """Footer/table hotkey when the owning row's table has keyboard focus."""
+
+
+# Extend this dict to add new per-row actions to any tab. Both the
+# Enter-triggered action menu and the table-focused footer hotkeys
+# (`_RowActionTable`, below) read from this single registry.
+_TAB_ROW_ACTIONS: dict[str, list[RowAction]] = {
     "project-events": [
-        ("select", "Select event"),
-        ("toggle_completed", "Toggle completed"),
-        ("view_seismograms", "View seismograms"),
-        ("delete", "Delete event"),
+        RowAction("select", "Select event", "s"),
+        RowAction("toggle_completed", "Toggle completed", "m"),
+        RowAction("view_seismograms", "View seismograms", "v"),
+        RowAction("delete", "Delete event", "d"),
     ],
     "project-stations": [
-        ("view_seismograms", "View seismograms"),
-        ("delete", "Delete station"),
+        RowAction("view_seismograms", "View seismograms", "v"),
+        RowAction("delete", "Delete station", "d"),
     ],
     "tab-seismograms": [
-        ("toggle_select", "Toggle select"),
-        ("toggle_flip", "Toggle flip"),
-        ("reset", "Reset parameters"),
-        ("delete", "Delete seismogram"),
+        RowAction("toggle_select", "Toggle select", "s"),
+        RowAction("toggle_flip", "Toggle flip", "f"),
+        RowAction("reset", "Reset seismogram", "u"),
+        RowAction("delete", "Delete seismogram", "d"),
+    ],
+    "tab-snapshots": [
+        RowAction("show_details", "Show details", "v"),
+        RowAction("preview_stack", "Preview stack", "s"),
+        RowAction("preview_image", "Preview matrix image", "x"),
+        RowAction("save_results", "Save results to JSON", "w"),
+        RowAction("rollback", "Rollback to this snapshot", "b"),
+        RowAction("delete", "Delete snapshot", "d"),
     ],
 }
 
@@ -125,23 +154,43 @@ def _setup_table(
     return table
 
 
+def _styled_cell(cell: str | Text, style: str) -> Text:
+    """Return `cell` as a `Text` with `style` applied, preserving any
+    existing `Text` formatting (e.g. `text_align`)."""
+    if isinstance(cell, Text):
+        styled = cell.copy()
+        styled.stylize(style)
+        return styled
+    return Text(cell, style=style)
+
+
 def _populate_rows(
     table: DataTable,
     rows: Sequence[dict[str, Any]],
     model: type[BaseModel],
     *,
     on_row: Callable[[dict[str, Any]], Sequence[str]] | None = None,
+    row_style: Callable[[dict[str, Any]], str | None] | None = None,
 ) -> None:
     """Add `rows` (dicts with title keys and an "ID" key) to `table`,
     formatting cells via `tui_cell(model, ...)`.
 
     If given, `on_row` is called with each row dict before "ID" is popped;
     its return value is prepended as extra leading cells (e.g. a marker).
+
+    If given, `row_style` is called with each row dict (before "ID" is
+    popped); when it returns a Rich style string, every cell in that row
+    (including any `on_row` prefix) is wrapped in that style, e.g. to fade
+    rows not relevant to the current context.
     """
     for row in rows:
-        prefix = on_row(row) if on_row is not None else ()
+        style = row_style(row) if row_style is not None else None
+        prefix: Sequence[str | Text] = on_row(row) if on_row is not None else ()
         row_id = str(row.pop("ID"))
-        cells = [tui_cell(model, k, v) for k, v in row.items()]
+        cells: Sequence[str | Text] = [tui_cell(model, k, v) for k, v in row.items()]
+        if style is not None:
+            prefix = [_styled_cell(c, style) for c in prefix]
+            cells = [_styled_cell(c, style) for c in cells]
         table.add_row(*prefix, *cells, key=row_id)
 
 
@@ -184,19 +233,100 @@ def _open_row_action_menu(
     tab: str,
     item_id: str,
     title: str,
-    make_message: Callable[[str, str, str], Message],
+    dispatch: Callable[[str, str, str], None],
 ) -> None:
-    """Open the row-action menu for `tab`, posting `make_message(tab, item_id, action)`
-    on `widget` if the user picks an action (does nothing if they cancel)."""
+    """Open the row-action menu for `tab`, calling `dispatch(tab, item_id, action)`
+    if the user picks an action (does nothing if they cancel)."""
     actions = _TAB_ROW_ACTIONS.get(tab, [])
     if not actions:
         return
 
     def on_action(action: str | None) -> None:
         if action is not None:
-            widget.post_message(make_message(tab, item_id, action))
+            dispatch(tab, item_id, action)
 
-    widget.app.push_screen(ActionMenuModal(title, actions), on_action)
+    widget.app.push_screen(
+        ActionMenuModal(title, [(a.id, a.label) for a in actions]), on_action
+    )
+
+
+class _RowActionTable(VimDataTable):
+    """`VimDataTable` that exposes its `_TAB_ROW_ACTIONS` entries as footer hotkeys.
+
+    Subclasses set `TAB_ID`; `BINDINGS` and `check_action` are derived from
+    `_TAB_ROW_ACTIONS[TAB_ID]` so the Enter-triggered action menu and the
+    footer hotkeys can never drift apart.
+    """
+
+    TAB_ID: ClassVar[str]
+
+    class RowActionSelected(Message):
+        """Posted when a row action is triggered directly via its footer hotkey."""
+
+        def __init__(
+            self, table: "_RowActionTable", row_key: str, action_id: str
+        ) -> None:
+            super().__init__()
+            self.table = table
+            self.row_key = row_key
+            self.action_id = action_id
+
+        @property
+        def control(self) -> "_RowActionTable":
+            return self.table
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        # Textual's own DOMNode.__init_subclass__ (called via super() below)
+        # merges BINDINGS across the MRO into cls._merged_bindings as part of
+        # its own class-setup work, so BINDINGS must already reflect this
+        # subclass's actions *before* that call, not after - getting this
+        # order wrong silently drops every row-action hotkey from the footer
+        # (row actions still work via Enter -> menu, so it's easy to miss).
+        # This depends on the internal ordering of an undocumented Textual
+        # mechanism, not a stable public contract; if a Textual upgrade ever
+        # changes it, TestRowActionFooterHotkeys in test_tui.py is what will
+        # fail and point back here.
+        cls.BINDINGS = [
+            Binding(a.key, f"row_action('{a.id}')", a.label, show=True)
+            for a in _TAB_ROW_ACTIONS[cls.TAB_ID]
+        ]
+        super().__init_subclass__(**kwargs)
+
+    def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
+        if action == "row_action":
+            return self.row_count > 0
+        return True
+
+    def action_row_action(self, action_id: str) -> None:
+        if self.row_count == 0:
+            return
+        row_key = self.coordinate_to_cell_key(self.cursor_coordinate).row_key.value
+        if row_key:
+            self.post_message(self.RowActionSelected(self, row_key, action_id))
+
+
+class _EventTable(_RowActionTable):
+    """Row-action-aware table for the Project tab's event list."""
+
+    TAB_ID = "project-events"
+
+
+class _StationTable(_RowActionTable):
+    """Row-action-aware table for the Project tab's station list."""
+
+    TAB_ID = "project-stations"
+
+
+class _SeismogramTable(_RowActionTable):
+    """Row-action-aware table for the Live data tab's seismogram list."""
+
+    TAB_ID = "tab-seismograms"
+
+
+class _SnapshotTable(_RowActionTable):
+    """Row-action-aware table for the Snapshots tab's snapshot list."""
+
+    TAB_ID = "tab-snapshots"
 
 
 # ---------------------------------------------------------------------------
@@ -224,8 +354,8 @@ class ProjectPanel(Widget):
     def compose(self) -> ComposeResult:
         with Horizontal(id="project-layout"):
             with Vertical(id="project-tables"):
-                yield VimDataTable(id="project-event-table")
-                yield VimDataTable(id="project-station-table")
+                yield _EventTable(id="project-event-table")
+                yield _StationTable(id="project-station-table")
             with Vertical(id="project-right-panel"):
                 yield Static(id="project-quality-panel", classes="quality-panel")
                 yield NoteWidget(id="project-note")
@@ -271,6 +401,18 @@ class ProjectPanel(Widget):
                     by_title=True,
                     exclude=_STATION_TABLE_EXCLUDE,
                 )
+                used_station_ids: set[str] = (
+                    {
+                        str(station_id)
+                        for station_id in session.exec(
+                            select(AimbatSeismogram.station_id)
+                            .where(AimbatSeismogram.event_id == current_event_id)
+                            .distinct()
+                        ).all()
+                    }
+                    if current_event_id is not None
+                    else set()
+                )
 
             total = len(event_rows)
             completed = sum(1 for r in event_rows if r.get("Completed"))
@@ -295,10 +437,22 @@ class ProjectPanel(Widget):
                     "▶" if str(row["ID"]) == str(current_event_id) else " ",
                 ),
             )
-            _populate_rows(st, station_rows, AimbatStationRead)
+            _populate_rows(
+                st,
+                station_rows,
+                AimbatStationRead,
+                row_style=lambda row: (
+                    None
+                    if current_event_id is None or str(row["ID"]) in used_station_ids
+                    else "dim"
+                ),
+            )
 
         self._refreshing = True
         _settle_cursor(self, [(et, et_saved), (st, st_saved)], self._on_settled)
+
+    def _dispatch_row_action(self, tab: str, item_id: str, action: str) -> None:
+        self.post_message(self.RowActionChosen(tab, item_id, action))
 
     @on(DataTable.RowSelected, "#project-event-table")
     def project_event_row_selected(self, event: DataTable.RowSelected) -> None:
@@ -308,7 +462,7 @@ class ProjectPanel(Widget):
                 "project-events",
                 event.row_key.value,
                 f"Event  {event.row_key.value[:8]}",
-                self.RowActionChosen,
+                self._dispatch_row_action,
             )
 
     @on(DataTable.RowSelected, "#project-station-table")
@@ -319,8 +473,15 @@ class ProjectPanel(Widget):
                 "project-stations",
                 event.row_key.value,
                 f"Station  {event.row_key.value[:8]}",
-                self.RowActionChosen,
+                self._dispatch_row_action,
             )
+
+    @on(_RowActionTable.RowActionSelected)
+    def _row_action_selected(self, message: _RowActionTable.RowActionSelected) -> None:
+        message.stop()
+        self._dispatch_row_action(
+            message.table.TAB_ID, message.row_key, message.action_id
+        )
 
     @on(DataTable.RowHighlighted, "#project-event-table")
     def project_event_row_highlighted(self, event: DataTable.RowHighlighted) -> None:
@@ -398,7 +559,7 @@ class SeismogramPanel(Widget):
 
     def compose(self) -> ComposeResult:
         with Horizontal(id="seismogram-layout"):
-            yield VimDataTable(id="seismogram-table")
+            yield _SeismogramTable(id="seismogram-table")
             with Vertical(id="seismogram-right-panel"):
                 yield SeismogramPlotWidget(id="seismogram-plot")
                 yield NoteWidget(id="seismogram-note")
@@ -492,6 +653,9 @@ class SeismogramPanel(Widget):
             self._update_seismogram_note(self._highlighted_id)
             self._update_seismogram_plot(self._highlighted_id)
 
+    def _dispatch_row_action(self, tab: str, item_id: str, action: str) -> None:
+        self.post_message(self.RowActionChosen(item_id, action))
+
     @on(DataTable.RowSelected, "#seismogram-table")
     def seismogram_row_selected(self, event: DataTable.RowSelected) -> None:
         if event.row_key.value:
@@ -500,8 +664,15 @@ class SeismogramPanel(Widget):
                 "tab-seismograms",
                 event.row_key.value,
                 f"Seismogram  {event.row_key.value[:8]}",
-                lambda tab, item_id, action: self.RowActionChosen(item_id, action),
+                self._dispatch_row_action,
             )
+
+    @on(_RowActionTable.RowActionSelected)
+    def _row_action_selected(self, message: _RowActionTable.RowActionSelected) -> None:
+        message.stop()
+        self._dispatch_row_action(
+            message.table.TAB_ID, message.row_key, message.action_id
+        )
 
     def _update_seismogram_note(self, item_id: str | None) -> None:
         _update_note(
@@ -579,7 +750,7 @@ class SnapshotPanel(Widget):
 
     def compose(self) -> ComposeResult:
         with Horizontal(id="snapshot-layout"):
-            yield VimDataTable(id="snapshot-table")
+            yield _SnapshotTable(id="snapshot-table")
             with Vertical(id="snapshot-right-panel"):
                 yield Static(id="snapshot-quality-panel", classes="quality-panel")
                 yield NoteWidget(id="snapshot-note")
@@ -640,7 +811,19 @@ class SnapshotPanel(Widget):
             self.post_message(self.ActionChosen(snap_id, action, context, all_seis))
 
         self.app.push_screen(
-            SnapshotActionMenuModal(f"Snapshot  {snap_id[:8]}"), on_action
+            SnapshotActionMenuModal(
+                f"Snapshot  {snap_id[:8]}", _TAB_ROW_ACTIONS["tab-snapshots"]
+            ),
+            on_action,
+        )
+
+    @on(_RowActionTable.RowActionSelected)
+    def _row_action_selected(self, message: _RowActionTable.RowActionSelected) -> None:
+        # Direct hotkeys use the modal's own default toggle values; non-default
+        # context/all_seismograms combinations still require Enter -> modal.
+        message.stop()
+        self.post_message(
+            self.ActionChosen(message.row_key, message.action_id, True, False)
         )
 
     def _update_snapshot_quality(self, item_id: str | None) -> None:

--- a/src/aimbat/_tui/aimbat.tcss
+++ b/src/aimbat/_tui/aimbat.tcss
@@ -112,25 +112,6 @@ ConfirmModal {
     color: $foreground;
 }
 
-/* ---- Event-switcher modal ---- */
-EventSwitcherModal {
-    align: center middle;
-}
-
-#switcher-dialog {
-    background: $background;
-    border: solid $primary;
-    width: 90%;
-    max-width: 110;
-    height: 70%;
-    padding: 1 2;
-}
-
-#switcher-dialog .modal-title {
-    color: $secondary;
-    text-style: bold;
-}
-
 /* ---- Snapshot action menu modal ---- */
 SnapshotActionMenuModal {
     align: center middle;
@@ -169,7 +150,7 @@ InteractiveToolsModal {
 #tools-dialog {
     background: $background;
     border: solid $primary;
-    width: 58;
+    width: 64;
     height: auto;
     padding: 1 2;
 }

--- a/src/aimbat/_tui/app.py
+++ b/src/aimbat/_tui/app.py
@@ -37,7 +37,6 @@ from aimbat._tui.modals import (
     ActionMenuModal,
     AlignModal,
     ConfirmModal,
-    EventSwitcherModal,
     HelpModal,
     InteractiveToolsModal,
     NoProjectModal,
@@ -45,6 +44,7 @@ from aimbat._tui.modals import (
     SchemaStaleModal,
     SnapshotCommentModal,
     SnapshotDetailsModal,
+    ToolLaunchResult,
 )
 from aimbat._types import SeismogramParameter
 from aimbat.core import (
@@ -98,10 +98,13 @@ _LIGHT_THEME = settings.tui_light_theme
 _MAIN_TABS = {"tab-project", "tab-seismograms", "tab-snapshots"}
 
 
-# Extend _TOOL_REGISTRY to register new interactive tools.  Each entry maps a
-# key to a (label, callable) pair.  The callable receives
-# (session, event, iccs, context, all_seismograms) and returns None.
+# Extend _TOOL_REGISTRY/_CAUSAL_TOOL_REGISTRY to register new interactive
+# tools.  Each entry maps a key to a (label, callable) pair.  Callables in
+# _TOOL_REGISTRY receive (session, event, iccs, context, all_seismograms);
+# callables in _CAUSAL_TOOL_REGISTRY additionally receive a causal argument
+# from InteractiveToolsModal's zero-phase toggle. Both return None.
 type _ToolFn = Callable[[Session, AimbatEvent, ICCS, bool, bool], None]
+type _CausalToolFn = Callable[[Session, AimbatEvent, ICCS, bool, bool, bool], None]
 
 
 def _tool_phase(
@@ -110,16 +113,15 @@ def _tool_phase(
     iccs: ICCS,
     context: bool,
     all_seismograms: bool,
+    causal: bool,
 ) -> None:
-    # TODO: expose a causal/zero-phase toggle once the TUI overhaul adds a
-    # widget-based equivalent of the CLI's --causal/--zero-phase flag.
     update_pick(
         session,
         iccs,
         context,
         all_seismograms=all_seismograms,
         use_matrix_image=False,
-        causal=True,
+        causal=causal,
         return_fig=False,
     )
 
@@ -130,9 +132,8 @@ def _tool_window(
     iccs: ICCS,
     context: bool,
     all_seismograms: bool,
+    causal: bool,
 ) -> None:
-    # TODO: expose a causal/zero-phase toggle once the TUI overhaul adds a
-    # widget-based equivalent of the CLI's --causal/--zero-phase flag.
     update_timewindow(
         session,
         event,
@@ -140,7 +141,7 @@ def _tool_window(
         context,
         all_seismograms=all_seismograms,
         use_matrix_image=False,
-        causal=False,
+        causal=causal,
         return_fig=False,
     )
 
@@ -151,16 +152,15 @@ def _tool_cc(
     iccs: ICCS,
     context: bool,
     all_seismograms: bool,
+    causal: bool,
 ) -> None:
-    # TODO: expose a causal/zero-phase toggle once the TUI overhaul adds a
-    # widget-based equivalent of the CLI's --causal/--zero-phase flag.
     update_min_cc(
         session,
         event,
         iccs,
         context,
         all_seismograms=all_seismograms,
-        causal=False,
+        causal=causal,
         return_fig=False,
     )
 
@@ -204,12 +204,14 @@ def _tool_image(
 
 
 _TOOL_REGISTRY: dict[str, tuple[str, _ToolFn]] = {
-    "phase": ("Phase arrival (t1)", _tool_phase),
-    "window": ("Time window", _tool_window),
-    "cc": ("Min CC", _tool_cc),
     "bandpass": ("Bandpass filter", _tool_bandpass),
     "stack": ("Stack plot", _tool_stack),
     "image": ("Matrix image", _tool_image),
+}
+_CAUSAL_TOOL_REGISTRY: dict[str, tuple[str, _CausalToolFn]] = {
+    "phase": ("Phase arrival (t1)", _tool_phase),
+    "window": ("Time window", _tool_window),
+    "cc": ("Min CC", _tool_cc),
 }
 
 
@@ -225,8 +227,7 @@ class AimbatTUI(App[None]):
     CSS_PATH = "aimbat.tcss"
 
     BINDINGS = [
-        Binding("e", "switch_event", "Events", show=True),
-        Binding("d", "add_data", "Add Data", show=True),
+        Binding("i", "add_data", "Add Data", show=True),
         Binding("p", "open_parameters", "Parameters", show=True),
         Binding("t", "open_interactive_tools", "Tools", show=True),
         Binding("a", "open_align", "Align", show=True),
@@ -326,13 +327,30 @@ class AimbatTUI(App[None]):
             self.query_one(SnapshotPanel).clear_selection_if_empty()
 
     def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
-        if action in {
-            "open_parameters",
-            "open_interactive_tools",
-            "open_align",
-            "new_snapshot",
-        }:
-            return self._current_event_id is not None
+        if action == "add_data":
+            return self._active_tab == "tab-project"
+        if action == "new_snapshot":
+            return (
+                self._active_tab == "tab-seismograms"
+                and self._current_event_id is not None
+            )
+        if action in {"open_interactive_tools", "open_align"}:
+            return (
+                self._active_tab == "tab-seismograms"
+                and self._current_event_id is not None
+            )
+        if action == "open_parameters":
+            if self._current_event_id is None:
+                return False
+            if self._active_tab == "tab-seismograms":
+                return True
+            if self._active_tab == "tab-project":
+                # `self.focused` is the DataTable itself when a table has
+                # keyboard focus (DataTable has no focusable descendants), so
+                # comparing its id directly is sufficient - this would need
+                # revisiting if DataTable ever grew focusable child widgets.
+                return getattr(self.focused, "id", None) == "project-event-table"
+            return False
         return True
 
     # ------------------------------------------------------------------
@@ -521,15 +539,17 @@ class AimbatTUI(App[None]):
                 )
                 bar.update(
                     f"▶ {time_str}  |  {lat}, {lon}{modified}"
-                    f"  [dim]{iccs_status}  e = switch event[/dim]"
+                    f"  [dim]{iccs_status}  switch events on the Project tab[/dim]"
                 )
         except NoResultFound:
             with Session(engine) as session:
                 has_events = session.exec(select(AimbatEvent)).first() is not None
             if has_events:
-                bar.update("[red]No event selected — press e to select one[/red]")
+                bar.update(
+                    "[red]No event selected — select one on the Project tab[/red]"
+                )
             else:
-                bar.update("[red]No data in project — press d to add data[/red]")
+                bar.update("[red]No data in project — press i to add data[/red]")
         except RuntimeError as exc:
             bar.update(f"[red]{exc}[/red]")
 
@@ -799,7 +819,10 @@ class AimbatTUI(App[None]):
                 event = self._get_current_event(session)
                 event_id = event.id
         except NoResultFound:
-            self.notify("No event selected — press e to select one", severity="warning")
+            self.notify(
+                "No event selected — select one on the Project tab",
+                severity="warning",
+            )
             return
 
         def on_close(changed: bool | None) -> None:
@@ -809,20 +832,6 @@ class AimbatTUI(App[None]):
                 self.refresh_all()
 
         self.push_screen(ParametersModal(event_id), on_close)
-
-    def action_switch_event(self) -> None:
-        def on_result(result: tuple[uuid.UUID | None, bool] | None) -> None:
-            selected_event_id, deleted_current_event = result or (None, False)
-            if selected_event_id is not None:
-                logger.debug(f"User switched to event {str(selected_event_id)[:8]}.")
-                self._current_event_id = selected_event_id
-                self._create_iccs()
-            elif deleted_current_event:
-                self._current_event_id = None
-                self._bound_iccs = None
-            self.refresh_all()
-
-        self.push_screen(EventSwitcherModal(self._current_event_id), on_result)
 
     def action_add_data(self) -> None:
         actions = [(dt.value, dt.name.replace("_", " ")) for dt in DataType]
@@ -872,40 +881,60 @@ class AimbatTUI(App[None]):
                 severity="warning",
             )
         else:
-            self.notify("No event selected — press e to select one", severity="warning")
+            self.notify(
+                "No event selected — select one on the Project tab",
+                severity="warning",
+            )
         return False
 
     def action_open_interactive_tools(self) -> None:
         if not self._require_iccs():
             return
 
-        def on_result(result: tuple[str, bool, bool] | None) -> None:
+        def on_result(result: ToolLaunchResult | None) -> None:
             if result is not None:
-                self._run_tool(*result)
+                self._run_tool(
+                    result.tool, result.context, result.all_seismograms, result.causal
+                )
 
         self.push_screen(InteractiveToolsModal(), on_result)
 
-    def _run_tool(self, tool: str, context: bool, all_seis: bool) -> None:
+    def _run_tool(
+        self, tool: str, context: bool, all_seis: bool, causal: bool | None
+    ) -> None:
         """Run an interactive tool, suspending Textual while matplotlib is active.
 
         Uses the long-lived ICCS instance (waveform data already loaded) and runs
         matplotlib on the main thread via App.suspend(), which is the correct
-        Textual pattern for blocking terminal-adjacent processes.
+        Textual pattern for blocking terminal-adjacent processes. `causal` is
+        only meaningful (non-None) for tools in _CAUSAL_TOOL_REGISTRY.
         """
         logger.debug(
-            f"User launched interactive tool '{tool}' (context={context}, all_seis={all_seis})."
+            f"User launched interactive tool '{tool}' "
+            f"(context={context}, all_seis={all_seis}, causal={causal})."
         )
         if self._bound_iccs is None:
             self.notify("ICCS not ready — please wait", severity="warning")
             return
-        label, fn = _TOOL_REGISTRY[tool]
         iccs = self._bound_iccs.iccs
+        is_causal_tool = tool in _CAUSAL_TOOL_REGISTRY
+        label = (
+            _CAUSAL_TOOL_REGISTRY[tool][0]
+            if is_causal_tool
+            else _TOOL_REGISTRY[tool][0]
+        )
 
         try:
             with self._suspend(label):
                 with Session(engine) as session:
                     event = self._get_current_event(session)
-                    fn(session, event, iccs, context, all_seis)
+                    if is_causal_tool:
+                        assert causal is not None
+                        _CAUSAL_TOOL_REGISTRY[tool][1](
+                            session, event, iccs, context, all_seis, causal
+                        )
+                    else:
+                        _TOOL_REGISTRY[tool][1](session, event, iccs, context, all_seis)
         except Exception as exc:
             logger.exception(f"Interactive tool '{tool}' raised: {exc}")
             self.notify(str(exc), severity="error")

--- a/src/aimbat/_tui/help/tab-project.md
+++ b/src/aimbat/_tui/help/tab-project.md
@@ -1,14 +1,32 @@
 # Project tab
 
-This is the starting point. The Project tab gives you an overview of
-everything in the database: the seismic events and the recording stations.
-**Most processing in AIMBAT is per-event** — you need to select an event
-here before the Live data and Snapshots tabs show anything useful.
+The Project tab lists everything in the database: seismic events and
+recording stations. **Most processing in AIMBAT is per-event** — select an
+event here before the Live data and Snapshots tabs show anything.
 
 **Changes are written to the database immediately** — there is no save step
-and no undo. Press `n` to create a snapshot of the current parameter state
-that you can roll back to later; taking one right after importing data is
-good practice, since it gives you a baseline to restore to.
+and no undo. On the Live data tab, press `n` to create a snapshot of the
+current parameter state to roll back to later. Data imported via the CLI
+(`aimbat data add`) already takes an automatic snapshot of each newly
+imported event, so a manual snapshot right after import is not necessary.
+
+---
+
+## Row action hotkeys vs. the Enter menu
+
+Every row action below is reachable two ways:
+
+- **Hotkey** — focus the table (`Tab` switches focus between Events and
+  Stations) and press the action's key. The key is shown in the footer
+  while that table has focus.
+- **Menu** — press `Enter` on a row to open the same actions as a list.
+
+The hotkey path is faster. The menu path can expose options a single
+keypress cannot: on the Snapshots tab, the hotkeys for **Preview stack**
+and **Preview matrix image** always use the menu's default toggle values
+(context waveforms on, all seismograms off). Previewing with different
+toggle values requires the `Enter` menu, since those toggles only exist
+there.
 
 ---
 
@@ -16,17 +34,17 @@ good practice, since it gives you a baseline to restore to.
 
 ### Event bar (top of screen)
 
-The bar above the tabs always shows the currently selected event and its
-ICCS status:
+The bar above the tabs shows the currently selected event and its ICCS
+status:
 
 - **● ICCS ready** — the event's seismograms are loaded in memory and
-  alignment can run. This is the normal working state.
+  alignment can run.
 - **○ no ICCS** — ICCS is built automatically in the background when you
   select an event. If this status persists, the ICCS instance could not be
   built — usually because a parameter combination is invalid or a waveform
   file is missing. Press `p` to check the event parameters; the most common
-  cause is a time window longer than the available waveform data. Fix the
-  problem and the status updates automatically.
+  cause is a time window longer than the available waveform data. The
+  status updates automatically once the problem is fixed.
 
 ### Events table (top)
 
@@ -34,15 +52,17 @@ Lists every seismic event in the project. Each row shows the event's
 origin time, location, depth, and completion status. The highlighted row
 drives the quality panel and note on the right.
 
-Press `Enter` on an event row to open the action menu. The most important
-action is **Select event** — this loads the event's seismograms into
-memory and makes it the target for all processing commands (`a` Align,
-`t` Tools, `p` Parameters, `n` New Snapshot).
+With the events table focused, press `s` (or `Enter` → **Select event**) to
+select a row. This loads the event's seismograms into memory and makes it
+the target for processing: `p` Parameters is available here; `a` Align,
+`t` Tools, and `n` New Snapshot become available on the Live data tab.
 
 ### Stations table (bottom)
 
 Lists every recording station. Highlighting a station row switches the
-quality panel and note to show that station's data.
+quality panel and note to show that station's data. Once an event is
+selected, stations that did not record it are dimmed; the dimming updates
+when the selected event changes.
 
 ### Quality panel (right)
 
@@ -61,19 +81,19 @@ in the database.
 
 ## Row actions — Events
 
-| Action | Description |
-|--------|-------------|
-| Select event | Load this event for processing (populates Live data and Snapshots tabs) |
-| Toggle completed | Mark or unmark the event as done |
-| View seismograms | Switch to the Live data tab showing only this event's seismograms |
-| Delete event | Remove the event and all its seismograms from the project |
+| Key | Action | Description |
+|-----|--------|-------------|
+| `s` | Select event | Load this event for processing (populates Live data and Snapshots tabs) |
+| `m` | Toggle completed | Mark or unmark the event as done |
+| `v` | View seismograms | Switch to the Live data tab showing only this event's seismograms |
+| `d` | Delete event | Remove the event and all its seismograms from the project |
 
 ## Row actions — Stations
 
-| Action | Description |
-|--------|-------------|
-| View seismograms | Switch to the Live data tab filtered to this station |
-| Delete station | Remove the station from the project |
+| Key | Action | Description |
+|-----|--------|-------------|
+| `v` | View seismograms | Switch to the Live data tab filtered to this station |
+| `d` | Delete station | Remove the station from the project |
 
 ---
 
@@ -83,6 +103,7 @@ in the database.
 |-----|--------|
 | `j` / `↓` | Move down |
 | `k` / `↑` | Move up |
+| `h` / `l` | Scroll left / right (wide tables) |
 | `g` / `G` | Jump to top / bottom |
 | `Enter` | Open row action menu |
 | `Tab` | Switch focus between Events and Stations tables |
@@ -91,16 +112,13 @@ in the database.
 
 ## Global key bindings
 
-These work from any tab:
+These work from this tab. `p` additionally requires the Events table
+(not Stations) to be focused:
 
 | Key | Action |
 |-----|--------|
-| `e` | Open event switcher (quick select without leaving current tab) |
-| `d` | Add data files to the project |
-| `p` | Edit processing parameters for the selected event |
-| `a` | Run alignment (ICCS or MCCC) |
-| `t` | Open interactive tools (matplotlib picking, stack/matrix plots) |
-| `n` | Create a new snapshot for the selected event |
+| `i` | Add data files to the project |
+| `p` | Edit processing parameters for the selected event (Events table must be focused) |
 | `r` | Refresh all panels |
 | `c` | Toggle light/dark colour theme |
 | `H` / `L` | Switch tabs (vim-style left/right) |

--- a/src/aimbat/_tui/help/tab-seismograms.md
+++ b/src/aimbat/_tui/help/tab-seismograms.md
@@ -1,8 +1,8 @@
 # Live data tab
 
 This tab shows the seismograms for the currently selected event. If the
-table is empty, go to the **Project** tab and select an event first (`e`
-to open the event switcher, or `Enter` → **Select event** on any event row).
+table is empty, go to the **Project** tab and select an event first
+(`s`, or `Enter` → **Select event**, on any event row).
 
 **Everything here is synced directly to the database.** Row actions (toggle
 select, toggle flip, reset, delete) take effect immediately — there is no
@@ -47,8 +47,8 @@ that seismogram in two tabs:
   window used for alignment. This is exactly what ICCS correlates against
   the stack.
 - **Context** — the same trace with extra padding beyond the time window,
-  normalised within the window. Use this to judge whether the window
-  boundaries make sense in relation to the surrounding signal.
+  normalised within the window. Use this to check whether the window
+  boundaries fit the surrounding signal.
 
 The x-axis shows time in seconds relative to the phase-arrival pick (t1), or
 relative to t0 if t1 has not yet been set. The y-axis shows normalised
@@ -69,7 +69,8 @@ note, which persists in the database.
 3. Run ICCS (`a`) to align all selected seismograms.
 4. Use the interactive tools (`t`) to manually adjust picks or the time
    window if needed.
-5. Exclude obvious outliers with **Toggle select** (`Enter` on the row).
+5. Exclude obvious outliers with **Toggle select** (press `s` on the row,
+   or `Enter` for the menu).
 6. Take a snapshot (`n`) to save a checkpoint.
 7. Run MCCC (`a` → MCCC) for the final high-precision picks.
 
@@ -77,12 +78,15 @@ note, which persists in the database.
 
 ## Row actions
 
-| Action | Description |
-|--------|-------------|
-| Toggle select | Include or exclude this seismogram from the ICCS stack |
-| Toggle flip | Invert polarity — use this if a seismogram is clearly upside down |
-| Reset parameters | Restore all per-seismogram parameters (t1, select, flip) to their defaults |
-| Delete seismogram | Remove this seismogram from the project permanently |
+Each action's key works directly once this table has focus, or via `Enter`
+for the equivalent menu.
+
+| Key | Action | Description |
+|-----|--------|-------------|
+| `s` | Toggle select | Include or exclude this seismogram from the ICCS stack |
+| `f` | Toggle flip | Invert polarity — use this if a seismogram is clearly upside down |
+| `u` | Reset seismogram | Restore all per-seismogram parameters (t1, select, flip) to their defaults |
+| `d` | Delete seismogram | Remove this seismogram from the project permanently |
 
 ---
 
@@ -92,6 +96,7 @@ note, which persists in the database.
 |-----|--------|
 | `j` / `↓` | Move down |
 | `k` / `↑` | Move up |
+| `h` / `l` | Scroll left / right (wide tables) |
 | `g` / `G` | Jump to top / bottom |
 | `Enter` | Open row action menu |
 
@@ -101,7 +106,6 @@ note, which persists in the database.
 
 | Key | Action |
 |-----|--------|
-| `e` | Open event switcher |
 | `a` | Run alignment (opens ICCS / MCCC menu) |
 | `t` | Open interactive tools |
 | `p` | Edit processing parameters |
@@ -109,3 +113,9 @@ note, which persists in the database.
 | `r` | Refresh all panels |
 | `?` | Show this help |
 | `q` | Quit |
+
+The tools modal (`t`) additionally supports `c` (toggle context waveforms)
+and `a` (include all seismograms) for every tool, and `z` (zero-phase
+instead of causal filtering) for phase pick, time window, and min CC. The
+alignment modal (`a`) supports `f` (autoflip) and `s` (autoselect) for ICCS,
+and `a` (include all seismograms) for MCCC.

--- a/src/aimbat/_tui/help/tab-snapshots.md
+++ b/src/aimbat/_tui/help/tab-snapshots.md
@@ -1,12 +1,11 @@
 # Snapshots tab
 
 A snapshot is a saved checkpoint of the current processing state — the
-time window, bandpass filter, picks, and per-seismogram flags. Snapshots
-let you experiment freely: take one before making changes, and roll back
-if things go wrong.
+time window, bandpass filter, picks, and per-seismogram flags. Take one
+before making changes, then roll back to it if needed.
 
 If the list is empty, go to the **Project** tab and select an event first,
-then press `n` to create a snapshot.
+then switch to the Live data tab and press `n` to create a snapshot.
 
 ---
 
@@ -42,21 +41,25 @@ needed. Each snapshot has its own note, which persists in the database.
 - **Quality metrics** — ICCS correlation coefficients per seismogram (always captured);
   MCCC metrics (only if MCCC has been run with the current parameters)
 
-Waveform data is not copied — snapshots are lightweight records of where
-you are in the parameter space.
+Waveform data is not copied — snapshots only record parameter values.
 
 ---
 
 ## Row actions
 
-| Action | Description |
-|--------|-------------|
-| Show details | View the event parameters (window, filter, min CC) as saved |
-| Preview stack | Open the ICCS stack plot built from this snapshot's parameters, without changing anything in the database |
-| Preview matrix image | Open the cross-correlation matrix image from this snapshot |
-| Save results to JSON | Export the snapshot's quality metrics and picks to a JSON file via a file-save dialogue |
-| Rollback to this snapshot | Restore these parameters as the current live values — overwrites the current parameters for this event |
-| Delete snapshot | Permanently remove the snapshot (the live parameters are not affected) |
+Each action's key works directly once this table has focus, or via `Enter`
+for the equivalent menu. The direct hotkeys for the two preview actions use
+the menu's default toggle values (context on, all seismograms off) — open
+the menu with `Enter` to change them first.
+
+| Key | Action | Description |
+|-----|--------|-------------|
+| `v` | Show details | View the event parameters (window, filter, min CC) as saved |
+| `s` | Preview stack | Open the ICCS stack plot built from this snapshot's parameters, without changing anything in the database |
+| `x` | Preview matrix image | Open the cross-correlation matrix image from this snapshot |
+| `w` | Save results to JSON | Export the snapshot's quality metrics and picks to a JSON file via a file-save dialogue |
+| `b` | Rollback to this snapshot | Restore these parameters as the current live values — overwrites the current parameters for this event |
+| `d` | Delete snapshot | Permanently remove the snapshot (the live parameters are not affected) |
 
 ### About rollback
 
@@ -76,10 +79,12 @@ also restored from the best matching snapshot.
 |-----|--------|
 | `j` / `↓` | Move down |
 | `k` / `↑` | Move up |
+| `h` / `l` | Scroll left / right (wide tables) |
 | `g` / `G` | Jump to top / bottom |
 | `Enter` | Open row action menu |
 
-When previewing a stack or matrix image, two extra toggles appear:
+When previewing a stack or matrix image via the `Enter` menu, two extra
+toggles appear:
 - `c` — include context seismograms (wider view around the pick window)
 - `a` — include all seismograms, even those with `Select = ✗`
 
@@ -89,8 +94,6 @@ When previewing a stack or matrix image, two extra toggles appear:
 
 | Key | Action |
 |-----|--------|
-| `e` | Open event switcher |
-| `n` | Create a new snapshot for the current event |
 | `r` | Refresh all panels |
 | `?` | Show this help |
 | `q` | Quit |

--- a/src/aimbat/_tui/modals.py
+++ b/src/aimbat/_tui/modals.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import uuid
 from enum import StrEnum
 from pathlib import Path
+from typing import TYPE_CHECKING, NamedTuple
 
 from pandas import Timedelta
 from pydantic import ValidationError
@@ -16,15 +17,16 @@ from textual.containers import Container
 from textual.screen import ModalScreen
 from textual.widgets import DataTable, Input, Label, Markdown, Static
 
-from aimbat._tui._format import tui_cell, tui_display_title
+from aimbat._cli.common import CAUSAL_DEFAULTS
 from aimbat._tui._widgets import VimDataTable
 from aimbat._types import EventParameter
-from aimbat.core import delete_event, dump_event_table, set_event_parameter
+from aimbat.core import set_event_parameter
 from aimbat.db import engine
-from aimbat.models import AimbatEvent, AimbatEventRead
+from aimbat.models import AimbatEvent
 from aimbat.models._parameters import AimbatEventParametersBase
 
-_SWITCHER_EVENT_EXCLUDE: set[str] = {"snapshot_count", "last_modified"}
+if TYPE_CHECKING:
+    from aimbat._tui._panels import RowAction
 
 
 class _CSS(StrEnum):
@@ -40,7 +42,6 @@ class _Hint(StrEnum):
     SAVE_CANCEL = (
         "[@click='screen.save']⏎ save[/]   [@click='screen.cancel']⎋ cancel[/]"
     )
-    NAVIGATE_EVENT_SWITCHER = "↑↓ navigate   [@click='screen.select']⏎ select[/]   [@click='screen.toggle_completed']c complete[/]   [@click='screen.delete_event']⌫ delete[/]   [@click='screen.cancel']⎋ cancel[/]"
     NAVIGATE_SELECT_CANCEL = "↑↓ navigate   [@click='screen.select']⏎ select[/]   [@click='screen.cancel']⎋ cancel[/]"
     NAVIGATE_RUN_CANCEL = "↑↓ navigate   [@click='screen.select']⏎ run[/]   [@click='screen.cancel']⎋ cancel[/]"
     CONFIRM_CANCEL = "[@click='screen.confirm'][bold]y[/bold] / ⏎ confirm[/]   [@click='screen.cancel'][bold]n[/bold] / ⎋ cancel[/]"
@@ -52,7 +53,6 @@ __all__ = [
     "ActionMenuModal",
     "AlignModal",
     "ConfirmModal",
-    "EventSwitcherModal",
     "HelpModal",
     "InteractiveToolsModal",
     "NoProjectModal",
@@ -61,152 +61,8 @@ __all__ = [
     "SnapshotActionMenuModal",
     "SnapshotCommentModal",
     "SnapshotDetailsModal",
+    "ToolLaunchResult",
 ]
-
-
-# ---------------------------------------------------------------------------
-# Event-switcher modal
-# ---------------------------------------------------------------------------
-
-
-class EventSwitcherModal(ModalScreen[tuple[uuid.UUID | None, bool]]):
-    """Modal screen for selecting a seismic event to process.
-
-    Dismisses with `(selected_event_id, deleted_current_event)`: the UUID of
-    the event the user switched to (`None` if the modal was just cancelled),
-    and whether the previously-active event was deleted during this modal's
-    lifetime — both are carried in the dismiss result so callers don't need
-    to inspect the screen instance after the fact.
-    """
-
-    BINDINGS = [
-        Binding("escape", "cancel", "Cancel", show=False),
-        Binding("c", "toggle_completed", "Complete", show=True),
-        Binding("backspace", "delete_event", "Delete", show=True),
-    ]
-
-    def __init__(self, current_event_id: uuid.UUID | None = None) -> None:
-        """Initialise the modal.
-
-        Args:
-            current_event_id: ID of the currently active event, used to mark
-                the active row with a `▶` indicator.
-        """
-        super().__init__()
-        self._current_event_id = current_event_id
-        self._selected_event_id: str | None = None
-        self._deleted_current_event: bool = False
-
-    def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
-        """Disable destructive actions when no row is highlighted."""
-        if action in {"delete_event", "toggle_completed"}:
-            return True if self._selected_event_id else False
-        return True
-
-    def compose(self) -> ComposeResult:
-        with Container(id="switcher-dialog"):
-            yield Label("Switch Event", classes=_CSS.TITLE)
-            yield VimDataTable(id="event-table")
-            yield Label(_Hint.NAVIGATE_EVENT_SWITCHER, classes=_CSS.HINT)
-
-    def on_mount(self) -> None:
-        table = self.query_one(DataTable)
-        table.cursor_type = "row"
-        headers = [
-            tui_display_title(AimbatEventRead, f)
-            for f in AimbatEventRead.model_fields
-            if f not in _SWITCHER_EVENT_EXCLUDE | {"id"}
-        ]
-        table.add_columns(" ", *headers)
-        self._populate(table)
-
-    def _populate(self, table: DataTable) -> None:
-        """Fetch events from the database and populate `table` with rows."""
-        try:
-            with Session(engine) as session:
-                rows = dump_event_table(
-                    session,
-                    from_read_model=True,
-                    by_title=True,
-                    exclude=_SWITCHER_EVENT_EXCLUDE,
-                )
-            for row in rows:
-                row_id = str(row.pop("ID"))
-                marker = "▶" if row_id == str(self._current_event_id) else " "
-                cells = [tui_cell(AimbatEventRead, k, v) for k, v in row.items()]
-                table.add_row(marker, *cells, key=row_id)
-        except RuntimeError as exc:
-            self.notify(str(exc), severity="error")
-            self.dismiss((None, self._deleted_current_event))
-
-    def _refresh_table(self) -> None:
-        """Clear and repopulate the event table, preserving cursor position."""
-        table = self.query_one("#event-table", DataTable)
-        saved_row = table.cursor_row
-        table.clear()
-        self._populate(table)
-        if table.row_count > 0:
-            table.move_cursor(row=min(saved_row, table.row_count - 1))
-
-    @on(DataTable.RowHighlighted, "#event-table")
-    def row_highlighted(self, event: DataTable.RowHighlighted) -> None:
-        self._selected_event_id = event.row_key.value if event.row_key else None
-        self.refresh_bindings()
-
-    @on(DataTable.RowSelected, "#event-table")
-    def row_selected(self, event: DataTable.RowSelected) -> None:
-        row_key = event.row_key.value
-        if not row_key:
-            return
-        self.dismiss((uuid.UUID(row_key), self._deleted_current_event))
-
-    def action_toggle_completed(self) -> None:
-        event_id = self._selected_event_id
-        if not event_id:
-            return
-        try:
-            with Session(engine) as session:
-                event = session.get(AimbatEvent, uuid.UUID(event_id))
-                if event is None:
-                    return
-                event.parameters.completed = not event.parameters.completed
-                session.add(event)
-                session.commit()
-            self._refresh_table()
-        except Exception as exc:
-            self.notify(str(exc), severity="error")
-
-    def action_delete_event(self) -> None:
-        event_id = self._selected_event_id
-        if not event_id:
-            return
-
-        def on_confirm(confirmed: bool | None) -> None:
-            if not confirmed:
-                return
-            try:
-                with Session(engine) as session:
-                    delete_event(session, uuid.UUID(event_id))
-                self._selected_event_id = None
-                if (
-                    self._current_event_id is not None
-                    and uuid.UUID(event_id) == self._current_event_id
-                ):
-                    self._deleted_current_event = True
-                self._refresh_table()
-                self.notify("Event deleted", timeout=2)
-            except Exception as exc:
-                self.notify(str(exc), severity="error")
-
-        self.app.push_screen(
-            ConfirmModal("Delete this event and all its data?"), on_confirm
-        )
-
-    def action_select(self) -> None:
-        self.query_one(DataTable).action_select_cursor()
-
-    def action_cancel(self) -> None:
-        self.dismiss((None, self._deleted_current_event))
 
 
 # ---------------------------------------------------------------------------
@@ -618,15 +474,6 @@ class ActionMenuModal(ModalScreen[str | None]):
 # Snapshot action menu modal
 # ---------------------------------------------------------------------------
 
-_SNAPSHOT_ACTIONS: list[tuple[str, str]] = [
-    ("show_details", "Show details"),
-    ("preview_stack", "Preview stack"),
-    ("preview_image", "Preview matrix image"),
-    ("save_results", "Save results to JSON"),
-    ("rollback", "Rollback to this snapshot"),
-    ("delete", "Delete snapshot"),
-]
-
 _PREVIEW_ACTIONS: frozenset[str] = frozenset({"preview_stack", "preview_image"})
 
 
@@ -643,14 +490,17 @@ class SnapshotActionMenuModal(ModalScreen[tuple[str, bool, bool] | None]):
         Binding("a", "toggle_all", show=False),
     ]
 
-    def __init__(self, title: str) -> None:
+    def __init__(self, title: str, actions: list["RowAction"]) -> None:
         """Initialise the modal.
 
         Args:
             title: Heading displayed above the action list.
+            actions: Row actions shown as rows (same registry the Snapshots
+                tab's footer hotkeys are built from).
         """
         super().__init__()
         self._title = title
+        self._actions = actions
         self._use_context = True
         self._all_seis = False
         self._highlighted: str = ""
@@ -666,9 +516,9 @@ class SnapshotActionMenuModal(ModalScreen[tuple[str, bool, bool] | None]):
         table = self.query_one(DataTable)
         table.cursor_type = "row"
         table.add_column("action")
-        for key, label in _SNAPSHOT_ACTIONS:
-            table.add_row(label, key=key)
-        table.styles.height = len(_SNAPSHOT_ACTIONS)
+        for action in self._actions:
+            table.add_row(action.label, key=action.id)
+        table.styles.height = len(self._actions)
         table.focus()
 
     def _update_options(self) -> None:
@@ -727,23 +577,38 @@ _TOOLS: list[tuple[str, str]] = [
 ]
 
 
-class InteractiveToolsModal(ModalScreen[tuple[str, bool, bool] | None]):
+class ToolLaunchResult(NamedTuple):
+    """Result of choosing a tool in `InteractiveToolsModal`.
+
+    `causal` is `None` for tools that don't take a causal argument.
+    """
+
+    tool: str
+    context: bool
+    all_seismograms: bool
+    causal: bool | None
+
+
+class InteractiveToolsModal(ModalScreen[ToolLaunchResult | None]):
     """Menu for launching interactive matplotlib tools.
 
     Options are toggled with key bindings so no Checkbox widgets are needed.
-    Dismisses with (tool_key, context, all_seismograms) or None on cancel.
+    Dismisses with a `ToolLaunchResult` or None on cancel.
     """
 
     BINDINGS = [
         Binding("escape", "cancel", "Cancel", show=False),
         Binding("c", "toggle_context", "Context", show=False),
         Binding("a", "toggle_all", "All", show=False),
+        Binding("z", "toggle_zero_phase", "Zero-phase", show=False),
     ]
 
     def __init__(self) -> None:
         super().__init__()
         self._use_context = True
         self._all_seis = False
+        self._highlighted_tool: str = ""
+        self._causal: bool = True
 
     def compose(self) -> ComposeResult:
         with Container(id="tools-dialog"):
@@ -761,23 +626,38 @@ class InteractiveToolsModal(ModalScreen[tuple[str, bool, bool] | None]):
         table.add_column("tool")
         for key, label in _TOOLS:
             table.add_row(label, key=key)
+        self._highlighted_tool = _TOOLS[0][0]
+        self._causal = CAUSAL_DEFAULTS.get(self._highlighted_tool, True)
         self._update_options()
         table.focus()
 
     def _update_options(self) -> None:
-        """Refresh the context/all-seismograms toggle display."""
+        """Refresh the context/all-seismograms/zero-phase toggle display."""
         ctx = "✓" if self._use_context else "✗"
         al = "✓" if self._all_seis else "✗"
-        self.query_one("#tools-options", Static).update(
+        options = (
             f"  [@click='screen.toggle_context'][dim]c[/dim] context: {ctx}[/]"
             f"   [@click='screen.toggle_all'][dim]a[/dim] all seismograms: {al}[/]"
         )
+        if self._highlighted_tool in CAUSAL_DEFAULTS:
+            zp = "✓" if not self._causal else "✗"
+            options += f"   [@click='screen.toggle_zero_phase'][dim]z[/dim] zero-phase: {zp}[/]"
+        self.query_one("#tools-options", Static).update(options)
+
+    @on(DataTable.RowHighlighted, "#tools-table")
+    def row_highlighted(self, event: DataTable.RowHighlighted) -> None:
+        self._highlighted_tool = event.row_key.value or ""
+        self._causal = CAUSAL_DEFAULTS.get(self._highlighted_tool, True)
+        self._update_options()
 
     @on(DataTable.RowSelected, "#tools-table")
     def row_selected(self, event: DataTable.RowSelected) -> None:
         key = event.row_key.value
         if key:
-            self.dismiss((key, self._use_context, self._all_seis))
+            causal = self._causal if key in CAUSAL_DEFAULTS else None
+            self.dismiss(
+                ToolLaunchResult(key, self._use_context, self._all_seis, causal)
+            )
 
     def action_toggle_context(self) -> None:
         self._use_context = not self._use_context
@@ -786,6 +666,11 @@ class InteractiveToolsModal(ModalScreen[tuple[str, bool, bool] | None]):
     def action_toggle_all(self) -> None:
         self._all_seis = not self._all_seis
         self._update_options()
+
+    def action_toggle_zero_phase(self) -> None:
+        if self._highlighted_tool in CAUSAL_DEFAULTS:
+            self._causal = not self._causal
+            self._update_options()
 
     def action_select(self) -> None:
         self.query_one(DataTable).action_select_cursor()

--- a/tests/functional/test_tui.py
+++ b/tests/functional/test_tui.py
@@ -13,11 +13,14 @@ monkeypatched to the test fixture's database:
 
 import asyncio
 import uuid
+from collections.abc import Generator
+from contextlib import contextmanager
 from typing import cast
 
 import pytest
 from sqlalchemy import Engine
 from sqlmodel import Session, select
+from textual.binding import Binding
 from textual.widgets import DataTable, Static, TabbedContent, TabPane
 
 import aimbat._tui._panels
@@ -26,7 +29,12 @@ import aimbat._tui.app
 import aimbat._tui.modals
 import aimbat.db
 from aimbat._tui.app import AimbatTUI
-from aimbat._tui.modals import SchemaStaleModal, SnapshotDetailsModal
+from aimbat._tui.modals import (
+    InteractiveToolsModal,
+    SchemaStaleModal,
+    SnapshotDetailsModal,
+    ToolLaunchResult,
+)
 from aimbat.core import (
     BoundICCS,
     create_snapshot,
@@ -587,3 +595,511 @@ class TestRowActionMenuWiring:
                 assert isinstance(pilot.app.screen, SnapshotDetailsModal)
 
         asyncio.run(_run())
+
+
+# ===========================================================================
+# Row-action footer hotkeys — table-aware footer (bypassing the Enter menu)
+# ===========================================================================
+
+
+@pytest.mark.slow
+class TestRowActionFooterHotkeys:
+    """Row actions are reachable directly as footer hotkeys when their table
+    has keyboard focus, not just via Enter -> menu (see `_RowActionTable` in
+    `_panels.py`)."""
+
+    def test_seismogram_hotkey_toggles_select(
+        self, loaded_engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Pressing 's' directly on a focused seismogram row toggles select,
+        with no Enter/menu navigation, and produces the same result the
+        Enter -> menu path does."""
+        _patch_engine(monkeypatch, loaded_engine)
+
+        with Session(loaded_engine) as session:
+            event = session.exec(select(AimbatEvent)).first()
+            assert event is not None
+            event_id = event.id
+
+        async def _run() -> uuid.UUID:
+            async with AimbatTUI().run_test(size=_TUI_SIZE) as pilot:
+                await pilot.pause(delay=0.5)
+                app = cast(AimbatTUI, pilot.app)
+                app._current_event_id = event_id
+                app.refresh_all()
+                await pilot.pause(delay=0.5)
+                await pilot.press("L")  # Project -> Live data
+                await pilot.pause()
+                table = pilot.app.query_one("#seismogram-table", DataTable)
+                table.focus()
+                await pilot.pause()
+                row_id = table.ordered_rows[0].key.value
+                assert row_id is not None
+                await pilot.press("s")  # direct hotkey, no menu
+                await pilot.pause(delay=0.3)
+                return uuid.UUID(row_id)
+
+        seismogram_id = asyncio.run(_run())
+
+        with Session(loaded_engine) as session:
+            seismogram = session.get(AimbatSeismogram, seismogram_id)
+            assert seismogram is not None
+            assert seismogram.parameters.select is False
+
+    def test_footer_shows_row_action_only_for_focused_table(
+        self, loaded_engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An events-table-only hotkey appears only while that table (not the
+        stations table) has keyboard focus."""
+        _patch_engine(monkeypatch, loaded_engine)
+
+        async def _run() -> None:
+            async with AimbatTUI().run_test(size=_TUI_SIZE) as pilot:
+                await pilot.pause(delay=0.5)
+                event_table = pilot.app.query_one("#project-event-table", DataTable)
+                event_table.focus()
+                await pilot.pause()
+                # "m" = toggle_completed, an events-table-only row action.
+                assert "m" in pilot.app.screen.active_bindings
+
+                station_table = pilot.app.query_one("#project-station-table", DataTable)
+                station_table.focus()
+                await pilot.pause()
+                assert "m" not in pilot.app.screen.active_bindings
+
+        asyncio.run(_run())
+
+    def test_footer_hides_row_action_when_table_empty(
+        self, patched_engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Row-action hotkeys are absent from the footer when their table has no rows."""
+        _patch_engine(monkeypatch, patched_engine)
+
+        async def _run() -> None:
+            async with AimbatTUI().run_test(size=_TUI_SIZE) as pilot:
+                await pilot.pause()
+                table = pilot.app.query_one("#project-event-table", DataTable)
+                assert table.row_count == 0
+                table.focus()
+                await pilot.pause()
+                assert "m" not in pilot.app.screen.active_bindings
+
+        asyncio.run(_run())
+
+
+# ===========================================================================
+# Hotkey scoping — add_data/tools/align/new_snapshot/parameters
+# ===========================================================================
+
+
+@pytest.mark.slow
+class TestHotkeyScoping:
+    """Top-level hotkeys are scoped to the tab (and, for parameters, the
+    table) they make sense on, via `AimbatTUI.check_action`."""
+
+    def test_add_data_key_is_i_not_d(self) -> None:
+        """`add_data` is bound to 'i'; 'd' is no longer bound to it anywhere
+        in the app-level BINDINGS (it is now the per-table delete hotkey)."""
+        keys_to_actions = {
+            b.key: b.action for b in AimbatTUI.BINDINGS if isinstance(b, Binding)
+        }
+        assert keys_to_actions.get("i") == "add_data"
+        assert "d" not in keys_to_actions
+
+    def test_add_data_hidden_outside_project_tab(
+        self, patched_engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_engine(monkeypatch, patched_engine)
+
+        async def _run() -> None:
+            async with AimbatTUI().run_test(size=_TUI_SIZE) as pilot:
+                await pilot.pause()
+                app = cast(AimbatTUI, pilot.app)
+                assert app.check_action("add_data", ()) is True
+                await pilot.press("L")  # Project -> Live data
+                await pilot.pause()
+                assert app.check_action("add_data", ()) is False
+                assert "i" not in pilot.app.screen.active_bindings
+
+        asyncio.run(_run())
+
+    def test_new_snapshot_only_on_seismograms_tab(
+        self, loaded_engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_engine(monkeypatch, loaded_engine)
+
+        with Session(loaded_engine) as session:
+            event = session.exec(select(AimbatEvent)).first()
+            assert event is not None
+            event_id = event.id
+
+        async def _run() -> None:
+            async with AimbatTUI().run_test(size=_TUI_SIZE) as pilot:
+                await pilot.pause(delay=0.5)
+                app = cast(AimbatTUI, pilot.app)
+                app._current_event_id = event_id
+                app.refresh_all()
+                await pilot.pause(delay=0.5)
+                assert app.check_action("new_snapshot", ()) is False  # tab-project
+
+                await pilot.press("L")  # -> tab-seismograms
+                await pilot.pause()
+                assert app.check_action("new_snapshot", ()) is True
+
+                await pilot.press("L")  # -> tab-snapshots
+                await pilot.pause()
+                assert app.check_action("new_snapshot", ()) is False
+
+        asyncio.run(_run())
+
+    def test_tools_and_align_hidden_outside_seismograms_tab(
+        self, loaded_engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_engine(monkeypatch, loaded_engine)
+
+        with Session(loaded_engine) as session:
+            event = session.exec(select(AimbatEvent)).first()
+            assert event is not None
+            event_id = event.id
+
+        async def _run() -> None:
+            async with AimbatTUI().run_test(size=_TUI_SIZE) as pilot:
+                await pilot.pause(delay=0.5)
+                app = cast(AimbatTUI, pilot.app)
+                app._current_event_id = event_id
+                app.refresh_all()
+                await pilot.pause(delay=0.5)
+                for action in ("open_interactive_tools", "open_align"):
+                    assert app.check_action(action, ()) is False  # tab-project
+
+                await pilot.press("L")  # -> tab-seismograms
+                await pilot.pause()
+                for action in ("open_interactive_tools", "open_align"):
+                    assert app.check_action(action, ()) is True
+                assert "t" in pilot.app.screen.active_bindings
+                assert "a" in pilot.app.screen.active_bindings
+
+                await pilot.press("L")  # -> tab-snapshots
+                await pilot.pause()
+                for action in ("open_interactive_tools", "open_align"):
+                    assert app.check_action(action, ()) is False
+
+        asyncio.run(_run())
+
+    def test_parameters_visible_on_events_table_not_stations_table(
+        self, loaded_engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_engine(monkeypatch, loaded_engine)
+
+        with Session(loaded_engine) as session:
+            event = session.exec(select(AimbatEvent)).first()
+            assert event is not None
+            event_id = event.id
+
+        async def _run() -> None:
+            async with AimbatTUI().run_test(size=_TUI_SIZE) as pilot:
+                await pilot.pause(delay=0.5)
+                app = cast(AimbatTUI, pilot.app)
+                app._current_event_id = event_id
+                app.refresh_all()
+                await pilot.pause(delay=0.5)
+
+                event_table = pilot.app.query_one("#project-event-table", DataTable)
+                event_table.focus()
+                await pilot.pause()
+                assert app.check_action("open_parameters", ()) is True
+                assert "p" in pilot.app.screen.active_bindings
+
+                station_table = pilot.app.query_one("#project-station-table", DataTable)
+                station_table.focus()
+                await pilot.pause()
+                assert app.check_action("open_parameters", ()) is False
+                assert "p" not in pilot.app.screen.active_bindings
+
+        asyncio.run(_run())
+
+    def test_parameters_visible_on_seismograms_tab(
+        self, loaded_engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_engine(monkeypatch, loaded_engine)
+
+        with Session(loaded_engine) as session:
+            event = session.exec(select(AimbatEvent)).first()
+            assert event is not None
+            event_id = event.id
+
+        async def _run() -> None:
+            async with AimbatTUI().run_test(size=_TUI_SIZE) as pilot:
+                await pilot.pause(delay=0.5)
+                app = cast(AimbatTUI, pilot.app)
+                app._current_event_id = event_id
+                app.refresh_all()
+                await pilot.pause(delay=0.5)
+
+                # Leave focus on the stations table (where 'p' is hidden),
+                # then switch tabs — the seismograms-tab branch must not
+                # inherit that restriction.
+                station_table = pilot.app.query_one("#project-station-table", DataTable)
+                station_table.focus()
+                await pilot.pause()
+                await pilot.press("L")  # -> tab-seismograms
+                await pilot.pause()
+                assert app.check_action("open_parameters", ()) is True
+                assert "p" in pilot.app.screen.active_bindings
+
+        asyncio.run(_run())
+
+    def test_parameters_hidden_on_snapshots_tab(
+        self, loaded_engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_engine(monkeypatch, loaded_engine)
+
+        with Session(loaded_engine) as session:
+            event = session.exec(select(AimbatEvent)).first()
+            assert event is not None
+            event_id = event.id
+
+        async def _run() -> None:
+            async with AimbatTUI().run_test(size=_TUI_SIZE) as pilot:
+                await pilot.pause(delay=0.5)
+                app = cast(AimbatTUI, pilot.app)
+                app._current_event_id = event_id
+                app.refresh_all()
+                await pilot.pause(delay=0.5)
+                await pilot.press("L")  # -> tab-seismograms
+                await pilot.press("L")  # -> tab-snapshots
+                await pilot.pause()
+                assert app.check_action("open_parameters", ()) is False
+                assert "p" not in pilot.app.screen.active_bindings
+
+        asyncio.run(_run())
+
+
+# ===========================================================================
+# Event-switcher retirement
+# ===========================================================================
+
+
+@pytest.mark.slow
+class TestEventSwitcherRetirement:
+    """The global 'e' hotkey and `EventSwitcherModal` are gone; event
+    selection only happens via the Project tab's event table."""
+
+    def test_e_key_is_not_bound(self) -> None:
+        keys = {b.key for b in AimbatTUI.BINDINGS if isinstance(b, Binding)}
+        assert "e" not in keys
+
+    def test_e_key_press_does_nothing(
+        self, patched_engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_engine(monkeypatch, patched_engine)
+
+        async def _run() -> None:
+            async with AimbatTUI().run_test(size=_TUI_SIZE) as pilot:
+                await pilot.pause()
+                depth_before = len(pilot.app.screen_stack)
+                await pilot.press("e")
+                await pilot.pause()
+                # No modal was pushed in response to the unbound key.
+                assert len(pilot.app.screen_stack) == depth_before
+
+        asyncio.run(_run())
+
+    def test_event_bar_hint_no_longer_mentions_e(
+        self, loaded_engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With an event selected, the bar's dimmed hint points at the
+        Project tab instead of the retired 'e' hotkey."""
+        _patch_engine(monkeypatch, loaded_engine)
+
+        with Session(loaded_engine) as session:
+            event = session.exec(select(AimbatEvent)).first()
+            assert event is not None
+            event_id = event.id
+
+        async def _run() -> None:
+            async with AimbatTUI().run_test(size=_TUI_SIZE) as pilot:
+                await pilot.pause(delay=0.5)
+                app = cast(AimbatTUI, pilot.app)
+                app._current_event_id = event_id
+                app.refresh_all()
+                await pilot.pause(delay=0.5)
+                bar = pilot.app.query_one("#event-bar", Static)
+                text = str(bar.render())
+                assert "e = switch event" not in text
+                assert "press e" not in text
+                assert "Project tab" in text
+
+        asyncio.run(_run())
+
+
+# ===========================================================================
+# Causal/zero-phase toggle — InteractiveToolsModal + _run_tool dispatch
+# ===========================================================================
+
+
+@pytest.mark.slow
+class TestCausalZeroPhaseToggle:
+    """The interactive-tools modal's zero-phase toggle, and its wiring
+    through `ToolLaunchResult`/`_run_tool` into the causal-aware tools."""
+
+    def test_causal_toggle_hidden_for_non_causal_tool(
+        self, patched_engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_engine(monkeypatch, patched_engine)
+
+        async def _run() -> None:
+            async with AimbatTUI().run_test(size=_TUI_SIZE) as pilot:
+                await pilot.pause()
+                modal = InteractiveToolsModal()
+                pilot.app.push_screen(modal)
+                await pilot.pause()
+                table = modal.query_one("#tools-table", DataTable)
+                # _TOOLS[3] == "bandpass", a non-causal tool.
+                table.move_cursor(row=3)
+                await pilot.pause()
+                assert "zero-phase" not in str(
+                    modal.query_one("#tools-options", Static).render()
+                )
+
+        asyncio.run(_run())
+
+    def test_causal_toggle_defaults_per_tool(
+        self, patched_engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_engine(monkeypatch, patched_engine)
+
+        async def _run() -> None:
+            async with AimbatTUI().run_test(size=_TUI_SIZE) as pilot:
+                await pilot.pause()
+                modal = InteractiveToolsModal()
+                pilot.app.push_screen(modal)
+                await pilot.pause()
+                # _TOOLS[0] == "phase", causal default True.
+                assert modal._causal is True
+                table = modal.query_one("#tools-table", DataTable)
+                # _TOOLS[1] == "window", causal default False.
+                table.move_cursor(row=1)
+                await pilot.pause()
+                assert modal._causal is False
+
+        asyncio.run(_run())
+
+    def test_run_tool_passes_causal_through(
+        self, loaded_engine_from_file: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A non-default causal toggle reaches `update_pick`, not just the
+        registry dispatch — the actual regression the ToolLaunchResult /
+        mixed-arity-registry design in decision 7 is guarding against."""
+        _patch_engine(monkeypatch, loaded_engine_from_file)
+
+        @contextmanager
+        def _noop_suspend(
+            self: AimbatTUI, label: str | None = None
+        ) -> Generator[None, None, None]:
+            yield
+
+        monkeypatch.setattr(AimbatTUI, "_suspend", _noop_suspend)
+
+        captured: dict[str, object] = {}
+
+        def _fake_update_pick(
+            session: object,
+            iccs: object,
+            context: object,
+            *,
+            all_seismograms: object,
+            use_matrix_image: object,
+            causal: object,
+            return_fig: object,
+        ) -> None:
+            captured["causal"] = causal
+
+        monkeypatch.setattr(aimbat._tui.app, "update_pick", _fake_update_pick)
+
+        async def _run() -> None:
+            async with AimbatTUI().run_test(size=_TUI_SIZE) as pilot:
+                app = cast(AimbatTUI, pilot.app)
+                await _wait_for_iccs_worker(app)
+                with Session(loaded_engine_from_file) as session:
+                    event = session.exec(select(AimbatEvent)).first()
+                assert event is not None
+                app._current_event_id = event.id
+                app._create_iccs()
+                await _wait_for_iccs_worker(app)
+                assert app._bound_iccs is not None
+
+                # "phase"'s causal default is True; pass the non-default
+                # value through explicitly.
+                app._run_tool("phase", True, False, False)
+                await pilot.pause()
+
+        asyncio.run(_run())
+        assert captured["causal"] is False
+
+    def test_run_tool_ignores_causal_for_non_causal_tools(
+        self, loaded_engine_from_file: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A non-causal tool's registry function is never called with a
+        `causal` argument, even though `_run_tool` receives one."""
+        _patch_engine(monkeypatch, loaded_engine_from_file)
+
+        @contextmanager
+        def _noop_suspend(
+            self: AimbatTUI, label: str | None = None
+        ) -> Generator[None, None, None]:
+            yield
+
+        monkeypatch.setattr(AimbatTUI, "_suspend", _noop_suspend)
+
+        calls: list[dict[str, object]] = []
+
+        def _fake_update_bandpass(*args: object, **kwargs: object) -> None:
+            calls.append(kwargs)
+
+        monkeypatch.setattr(aimbat._tui.app, "update_bandpass", _fake_update_bandpass)
+
+        async def _run() -> None:
+            async with AimbatTUI().run_test(size=_TUI_SIZE) as pilot:
+                app = cast(AimbatTUI, pilot.app)
+                await _wait_for_iccs_worker(app)
+                with Session(loaded_engine_from_file) as session:
+                    event = session.exec(select(AimbatEvent)).first()
+                assert event is not None
+                app._current_event_id = event.id
+                app._create_iccs()
+                await _wait_for_iccs_worker(app)
+                assert app._bound_iccs is not None
+
+                app._run_tool("bandpass", True, False, None)
+                await pilot.pause()
+
+        asyncio.run(_run())
+        assert len(calls) == 1
+        assert "causal" not in calls[0]
+
+    def test_tool_launch_result_causal_is_none_for_non_causal_tools(
+        self, patched_engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_engine(monkeypatch, patched_engine)
+
+        results: list[ToolLaunchResult | None] = []
+
+        async def _run() -> None:
+            async with AimbatTUI().run_test(size=_TUI_SIZE) as pilot:
+                await pilot.pause()
+                modal = InteractiveToolsModal()
+                pilot.app.push_screen(modal, results.append)
+                await pilot.pause()
+                table = modal.query_one("#tools-table", DataTable)
+                table.move_cursor(row=3)  # "bandpass"
+                await pilot.pause()
+                await pilot.press("enter")
+                await pilot.pause()
+
+        asyncio.run(_run())
+        assert len(results) == 1
+        result = results[0]
+        assert result is not None
+        assert result.tool == "bandpass"
+        assert result.causal is None

--- a/uv.lock
+++ b/uv.lock
@@ -1259,16 +1259,16 @@ wheels = [
 
 [[package]]
 name = "mkdocstrings-python"
-version = "2.0.6"
+version = "2.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "griffelib" },
     { name = "mkdocs-autorefs" },
     { name = "mkdocstrings" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/39/02/97c98a64de554251956d6584b61aea995c8fc3b2b2ca3e791209bcde071f/mkdocstrings_python-2.0.6.tar.gz", hash = "sha256:472a97ec73b40298970ec5db3eed7a5500361e5d76f67b528c5f4acce2fb74bd", size = 200642, upload-time = "2026-08-16T13:52:06.817Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/5d/1be1c7a49d8fa13dc80f66a85f53333d52cf5206911412006ffdff8fb9a0/mkdocstrings_python-2.0.7.tar.gz", hash = "sha256:8c49faf66d243072d7590a1b5dea028d9d7425fac191f54f096123a4a9c1a783", size = 201598, upload-time = "2026-08-17T16:56:18.239Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/37/ee6de2bde70f4f0fa279a4bb05fc8de723cb64d12f36be11d05f575dfaa7/mkdocstrings_python-2.0.6-py3-none-any.whl", hash = "sha256:0cb3d1f16c1a9131c0d88ec9e6047f343332b457f5c5b9d3a3203a4f93e65e48", size = 105268, upload-time = "2026-08-16T13:52:05.017Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6d/77546d8c26f038fce314a507106954f76270f6c182488bcf9ac9721175df/mkdocstrings_python-2.0.7-py3-none-any.whl", hash = "sha256:1fce5fbfe4ffa6e8136a35351cdc97c3bf55219c7efbd3f92a82260f93235d60", size = 105387, upload-time = "2026-08-17T16:56:16.813Z" },
 ]
 
 [[package]]
@@ -2017,8 +2017,8 @@ wheels = [
 
 [[package]]
 name = "pysmo"
-version = "1.0.0.dev101+gac5231ecb"
-source = { git = "https://github.com/pysmo/pysmo?rev=master#ac5231ecbba26a9f187b4faf46a21eeb9fa8d7d9" }
+version = "1.0.0.dev104+g66b9087c7"
+source = { git = "https://github.com/pysmo/pysmo?rev=master#66b9087c795f6147034a76bb312978e0637cc837" }
 dependencies = [
     { name = "annotated-types" },
     { name = "attrs" },


### PR DESCRIPTION
Row actions now work as direct hotkeys when their table has focus, not just via Enter -> menu. Retires the separate event-switcher modal/hotkey in favour of the Project tab's event table. Adds a zero-phase toggle to the interactive tools modal, backed by a shared CAUSAL_DEFAULTS constant. Dims stations not recording the selected event in the Project tab.

<!-- readthedocs-preview aimbat start -->
----
📚 Documentation preview 📚: https://aimbat--247.org.readthedocs.build/en/247/

<!-- readthedocs-preview aimbat end -->