### PR TITLE
refactor(tui): split app.py god object, dedupe core/_iccs helpers

### DIFF
--- a/src/aimbat/_tui/_iccs_lifecycle.py
+++ b/src/aimbat/_tui/_iccs_lifecycle.py
@@ -1,0 +1,179 @@
+"""ICCS background-worker lifecycle for the AIMBAT TUI.
+
+`_IccsLifecycleMixin` is the Textual-specific adapter around `IccsLifecycle`
+(`aimbat.core._iccs`): it owns the actual I/O and threading (reading
+waveform data in a background worker, marshalling results back to the main
+thread via `call_from_thread`) and calls into the shared, framework-agnostic
+`IccsLifecycle` object only to record outcomes and ask policy questions
+("is this stale", "should I retry", "is an instance ready"). A future non-TUI
+frontend (e.g. a Qt GUI) would reuse `IccsLifecycle` behind its own adapter
+using its own threading/notification primitives.
+
+Mixed into `AimbatTUI`, which provides `_current_event_id`,
+`_get_current_event`, and `refresh_all` (declared below only for the type
+checker; the real implementations live on the host class).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy.exc import NoResultFound
+from sqlmodel import Session
+from textual import work
+from textual.app import App
+
+from aimbat.core import BoundICCS, IccsLifecycle, create_iccs_instance
+from aimbat.db import engine
+from aimbat.logger import logger
+from aimbat.models import AimbatEvent
+
+
+class _IccsLifecycleMixin(App[None]):
+    """ICCS instance lifecycle: creation, staleness detection, readiness checks."""
+
+    _iccs_lifecycle: IccsLifecycle
+
+    # Provided by AimbatTUI; declared here only so the type checker accepts
+    # the calls below - the host class's own definitions take precedence.
+    _current_event_id: uuid.UUID | None
+
+    def _get_current_event(self, session: Session) -> AimbatEvent:
+        raise NotImplementedError
+
+    def refresh_all(self) -> None:
+        raise NotImplementedError
+
+    def _init_iccs_lifecycle(self) -> None:
+        """Reset ICCS lifecycle state and start the periodic staleness check."""
+        self._iccs_lifecycle = IccsLifecycle()
+        self.set_interval(5, self._check_iccs_staleness)
+
+    def _create_iccs(self, *, is_retry: bool = False) -> None:
+        """Discard the existing ICCS instance and create a new one in a background worker.
+
+        ICCS construction reads waveform data, so it must not block the asyncio event loop.
+        Concurrent calls are ignored — only one worker runs at a time.
+
+        Args:
+            is_retry: Whether this call is the one-shot retry made in
+                response to `IccsLifecycle.retry_pending` after a previous
+                failure. A retry call is not itself allowed to re-arm the
+                retry flag, so a persistently failing event gets exactly one
+                automatic retry rather than retrying forever.
+        """
+        if not self._iccs_lifecycle.start_creating():
+            logger.debug(
+                "ICCS creation already in progress; skipping duplicate request."
+            )
+            return
+        self._worker_create_iccs(is_retry)
+
+    @work(thread=True)
+    def _worker_create_iccs(self, is_retry: bool = False) -> None:
+        """Create the ICCS instance for the current event without blocking the UI.
+
+        On success, hands the new `BoundICCS` instance to `_assign_iccs` on
+        the main thread. On failure, notifies the user and, unless this call
+        is itself a retry, arms a one-shot retry for one further automatic
+        attempt.
+
+        Args:
+            is_retry: Whether this call is the one-shot retry after a
+                previous failure.
+        """
+        try:
+            with Session(engine) as session:
+                event = self._get_current_event(session)
+                bound_iccs = create_iccs_instance(session, event)
+        except (NoResultFound, RuntimeError):
+            logger.debug("ICCS worker: no event selected or no data; aborting.")
+            self.call_from_thread(self._iccs_lifecycle.mark_aborted)
+            return
+        except Exception as exc:
+            logger.exception(f"ICCS worker: unexpected error during creation: {exc}")
+            self.call_from_thread(
+                self.notify, f"ICCS init failed: {exc}", severity="error"
+            )
+            # Give the staleness poller one retry attempt on the next tick.
+            self.call_from_thread(self._iccs_lifecycle.mark_failed, is_retry=is_retry)
+            return
+        logger.debug("ICCS worker: instance created successfully.")
+        self.call_from_thread(self._assign_iccs, bound_iccs)
+
+    def _assign_iccs(self, bound_iccs: BoundICCS) -> None:
+        """Store the newly created ICCS instance and refresh all panels.
+
+        Discards the instance instead if the selected event changed while
+        the worker was building it (e.g. the event was deleted, or a
+        different event was selected, before this call ran) — otherwise a
+        slow, stale worker could bind an instance for an event that is no
+        longer current. When an event is still selected, immediately starts
+        a fresh attempt for it.
+
+        Args:
+            bound_iccs: The instance created by `_worker_create_iccs`.
+        """
+        if bound_iccs.event_id != self._current_event_id:
+            logger.debug(
+                "ICCS worker: discarding instance for an event that is no "
+                "longer selected."
+            )
+            self._iccs_lifecycle.mark_aborted()
+            if self._current_event_id is not None:
+                self._create_iccs()
+            return
+        self._iccs_lifecycle.assign(bound_iccs)
+        logger.info("ICCS instance ready and assigned.")
+        # Rebuilding ICCS re-upserts iccs_cc per seismogram, which also feeds
+        # ProjectPanel's quality panel and station cc_mean/cc_sem column.
+        self.refresh_all()
+
+    def _check_iccs_staleness(self) -> None:
+        """Trigger ICCS recreation if the current event has been modified externally.
+
+        When ICCS creation previously failed (e.g. due to an invalid parameter set via
+        the CLI), retries once, then waits for `event.last_modified` to change again
+        before retrying further — this avoids retrying forever against a persistently
+        failing event. On any detected change the full UI is refreshed so panels
+        reflect the new DB state immediately.
+        """
+        if self._current_event_id is None:
+            return
+        try:
+            with Session(engine) as session:
+                event = self._get_current_event(session)
+                stale = self._iccs_lifecycle.is_stale(event)
+        except (NoResultFound, RuntimeError):
+            return
+        if stale:
+            logger.debug(
+                "ICCS staleness detected; recreating instance and refreshing UI."
+            )
+            self._iccs_lifecycle.note_checked(event.last_modified)
+            self._create_iccs()
+            self.refresh_all()
+        elif self._iccs_lifecycle.retry_pending:
+            logger.debug("Retrying ICCS creation after a previous failure.")
+            self._create_iccs(is_retry=True)
+            self.refresh_all()
+
+    def _require_iccs(self) -> bool:
+        """Check that the ICCS instance is ready, showing a contextual warning otherwise.
+
+        Returns:
+            Whether the ICCS instance is ready to use.
+        """
+        if self._iccs_lifecycle.ready:
+            return True
+        if self._current_event_id is not None:
+            self.notify(
+                "ICCS not ready — check event parameters (Parameters tab)",
+                severity="warning",
+            )
+        else:
+            self.notify(
+                "No event selected — select one on the Project tab",
+                severity="warning",
+            )
+        return False

--- a/src/aimbat/_tui/_tools.py
+++ b/src/aimbat/_tui/_tools.py
@@ -1,0 +1,147 @@
+"""Interactive tool registry for the AIMBAT TUI.
+
+Extend `TOOL_REGISTRY`/`CAUSAL_TOOL_REGISTRY` to register new interactive
+tools. Each entry maps a key to a (label, callable) pair. Callables in
+`TOOL_REGISTRY` receive (session, event, iccs, context, all_seismograms);
+callables in `CAUSAL_TOOL_REGISTRY` additionally receive a causal argument
+from `InteractiveToolsModal`'s zero-phase toggle. Both return None.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from sqlmodel import Session
+
+from pysmo.tools.iccs import ICCS
+
+from aimbat.models import AimbatEvent
+from aimbat.plot import (
+    plot_matrix_image,
+    plot_stack,
+    update_bandpass,
+    update_min_cc,
+    update_pick,
+    update_timewindow,
+)
+
+type ToolFn = Callable[[Session, AimbatEvent, ICCS, bool, bool], None]
+type CausalToolFn = Callable[[Session, AimbatEvent, ICCS, bool, bool, bool], None]
+
+
+def _tool_phase(
+    session: Session,
+    event: AimbatEvent,
+    iccs: ICCS,
+    context: bool,
+    all_seismograms: bool,
+    causal: bool,
+) -> None:
+    """Launch the interactive phase-arrival (t1) picking tool."""
+    update_pick(
+        session,
+        iccs,
+        context,
+        all_seismograms=all_seismograms,
+        use_matrix_image=False,
+        causal=causal,
+        return_fig=False,
+    )
+
+
+def _tool_window(
+    session: Session,
+    event: AimbatEvent,
+    iccs: ICCS,
+    context: bool,
+    all_seismograms: bool,
+    causal: bool,
+) -> None:
+    """Launch the interactive time-window selection tool."""
+    update_timewindow(
+        session,
+        event,
+        iccs,
+        context,
+        all_seismograms=all_seismograms,
+        use_matrix_image=False,
+        causal=causal,
+        return_fig=False,
+    )
+
+
+def _tool_cc(
+    session: Session,
+    event: AimbatEvent,
+    iccs: ICCS,
+    context: bool,
+    all_seismograms: bool,
+    causal: bool,
+) -> None:
+    """Launch the interactive minimum-CC threshold tool."""
+    update_min_cc(
+        session,
+        event,
+        iccs,
+        context,
+        all_seismograms=all_seismograms,
+        causal=causal,
+        return_fig=False,
+    )
+
+
+def _tool_bandpass(
+    session: Session,
+    event: AimbatEvent,
+    iccs: ICCS,
+    context: bool,
+    all_seismograms: bool,
+) -> None:
+    """Launch the interactive bandpass-filter tool."""
+    update_bandpass(
+        session,
+        event,
+        iccs,
+        context,
+        all_seismograms=all_seismograms,
+        use_matrix_image=False,
+        return_fig=False,
+    )
+
+
+def _tool_stack(
+    session: Session,
+    event: AimbatEvent,
+    iccs: ICCS,
+    context: bool,
+    all_seismograms: bool,
+) -> None:
+    """Show the interactive stack plot."""
+    # session/event are unused here but required by ToolFn for a uniform
+    # TOOL_REGISTRY signature.
+    plot_stack(iccs, context, all_seismograms, return_fig=False)
+
+
+def _tool_image(
+    session: Session,
+    event: AimbatEvent,
+    iccs: ICCS,
+    context: bool,
+    all_seismograms: bool,
+) -> None:
+    """Show the interactive cross-correlation matrix image."""
+    # session/event are unused here but required by ToolFn for a uniform
+    # TOOL_REGISTRY signature.
+    plot_matrix_image(iccs, context, all_seismograms, return_fig=False)
+
+
+TOOL_REGISTRY: dict[str, tuple[str, ToolFn]] = {
+    "bandpass": ("Bandpass filter", _tool_bandpass),
+    "stack": ("Stack plot", _tool_stack),
+    "image": ("Matrix image", _tool_image),
+}
+CAUSAL_TOOL_REGISTRY: dict[str, tuple[str, CausalToolFn]] = {
+    "phase": ("Phase arrival (t1)", _tool_phase),
+    "window": ("Time window", _tool_window),
+    "cc": ("Min CC", _tool_cc),
+}

--- a/src/aimbat/_tui/app.py
+++ b/src/aimbat/_tui/app.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import uuid
-from collections.abc import Callable, Generator
+from collections.abc import Generator
 from contextlib import contextmanager, suppress
 from pathlib import Path
 from typing import Literal
@@ -29,10 +29,10 @@ from textual.widgets import (
 )
 from textual_fspicker import FileOpen, FileSave, Filters
 
-from pysmo.tools.iccs import ICCS
-
 from aimbat import settings
+from aimbat._tui._iccs_lifecycle import _IccsLifecycleMixin
 from aimbat._tui._panels import ProjectPanel, SeismogramPanel, SnapshotPanel
+from aimbat._tui._tools import CAUSAL_TOOL_REGISTRY, TOOL_REGISTRY
 from aimbat._tui.modals import (
     ActionMenuModal,
     AlignModal,
@@ -51,7 +51,6 @@ from aimbat.core import (
     BoundICCS,
     add_data_to_project,
     build_iccs_from_snapshot,
-    create_iccs_instance,
     create_project,
     create_snapshot,
     delete_event,
@@ -65,6 +64,7 @@ from aimbat.core import (
     run_iccs,
     run_mccc,
     set_seismogram_parameter,
+    toggle_event_completed,
     upgrade_project,
 )
 from aimbat.core._migrations import SchemaMismatchError, _build_staleness_warning
@@ -79,15 +79,7 @@ from aimbat.models import (
     AimbatSnapshot,
     AimbatStation,
 )
-from aimbat.plot import (
-    plot_matrix_image,
-    plot_seismograms,
-    plot_stack,
-    update_bandpass,
-    update_min_cc,
-    update_pick,
-    update_timewindow,
-)
+from aimbat.plot import plot_matrix_image, plot_seismograms, plot_stack
 from aimbat.utils.formatters import fmt_timestamp
 
 from ._format import tui_cell, tui_display_title
@@ -98,142 +90,20 @@ _LIGHT_THEME = settings.tui_light_theme
 _MAIN_TABS = {"tab-project", "tab-seismograms", "tab-snapshots"}
 
 
-# Extend _TOOL_REGISTRY/_CAUSAL_TOOL_REGISTRY to register new interactive
-# tools.  Each entry maps a key to a (label, callable) pair.  Callables in
-# _TOOL_REGISTRY receive (session, event, iccs, context, all_seismograms);
-# callables in _CAUSAL_TOOL_REGISTRY additionally receive a causal argument
-# from InteractiveToolsModal's zero-phase toggle. Both return None.
-type _ToolFn = Callable[[Session, AimbatEvent, ICCS, bool, bool], None]
-type _CausalToolFn = Callable[[Session, AimbatEvent, ICCS, bool, bool, bool], None]
-
-
-def _tool_phase(
-    session: Session,
-    event: AimbatEvent,
-    iccs: ICCS,
-    context: bool,
-    all_seismograms: bool,
-    causal: bool,
-) -> None:
-    """Launch the interactive phase-arrival (t1) picking tool."""
-    update_pick(
-        session,
-        iccs,
-        context,
-        all_seismograms=all_seismograms,
-        use_matrix_image=False,
-        causal=causal,
-        return_fig=False,
-    )
-
-
-def _tool_window(
-    session: Session,
-    event: AimbatEvent,
-    iccs: ICCS,
-    context: bool,
-    all_seismograms: bool,
-    causal: bool,
-) -> None:
-    """Launch the interactive time-window selection tool."""
-    update_timewindow(
-        session,
-        event,
-        iccs,
-        context,
-        all_seismograms=all_seismograms,
-        use_matrix_image=False,
-        causal=causal,
-        return_fig=False,
-    )
-
-
-def _tool_cc(
-    session: Session,
-    event: AimbatEvent,
-    iccs: ICCS,
-    context: bool,
-    all_seismograms: bool,
-    causal: bool,
-) -> None:
-    """Launch the interactive minimum-CC threshold tool."""
-    update_min_cc(
-        session,
-        event,
-        iccs,
-        context,
-        all_seismograms=all_seismograms,
-        causal=causal,
-        return_fig=False,
-    )
-
-
-def _tool_bandpass(
-    session: Session,
-    event: AimbatEvent,
-    iccs: ICCS,
-    context: bool,
-    all_seismograms: bool,
-) -> None:
-    """Launch the interactive bandpass-filter tool."""
-    update_bandpass(
-        session,
-        event,
-        iccs,
-        context,
-        all_seismograms=all_seismograms,
-        use_matrix_image=False,
-        return_fig=False,
-    )
-
-
-def _tool_stack(
-    session: Session,
-    event: AimbatEvent,
-    iccs: ICCS,
-    context: bool,
-    all_seismograms: bool,
-) -> None:
-    """Show the interactive stack plot."""
-    plot_stack(iccs, context, all_seismograms, return_fig=False)
-
-
-def _tool_image(
-    session: Session,
-    event: AimbatEvent,
-    iccs: ICCS,
-    context: bool,
-    all_seismograms: bool,
-) -> None:
-    """Show the interactive cross-correlation matrix image."""
-    plot_matrix_image(iccs, context, all_seismograms, return_fig=False)
-
-
-_TOOL_REGISTRY: dict[str, tuple[str, _ToolFn]] = {
-    "bandpass": ("Bandpass filter", _tool_bandpass),
-    "stack": ("Stack plot", _tool_stack),
-    "image": ("Matrix image", _tool_image),
-}
-_CAUSAL_TOOL_REGISTRY: dict[str, tuple[str, _CausalToolFn]] = {
-    "phase": ("Phase arrival (t1)", _tool_phase),
-    "window": ("Time window", _tool_window),
-    "cc": ("Min CC", _tool_cc),
-}
-
-
 # ---------------------------------------------------------------------------
 # Main application
 # ---------------------------------------------------------------------------
 
 
-class AimbatTUI(App[None]):
+class AimbatTUI(_IccsLifecycleMixin, App[None]):
     """Root screen of the AIMBAT Terminal User Interface.
 
     Composes a header, an event status bar, a tabbed content area (Project,
     Live data, Snapshots) and a footer. Owns the current active event, the
     long-lived `BoundICCS` instance used by the Live data tab and the
-    interactive tools, and dispatches row actions and key bindings to the
-    corresponding core functions.
+    interactive tools (lifecycle managed by `_IccsLifecycleMixin`), and
+    dispatches row actions and key bindings to the corresponding core
+    functions.
     """
 
     TITLE = "AIMBAT"
@@ -275,16 +145,11 @@ class AimbatTUI(App[None]):
         ICCS instance for the current event (if any) and populates all
         panels. Also starts the periodic ICCS staleness check.
         """
-        self._bound_iccs: BoundICCS | None = None
-        self._iccs_creating: bool = False
-        self._iccs_last_modified_seen: Timestamp | None = None
-        self._iccs_retry_pending: bool = False
+        self._init_iccs_lifecycle()
         self._current_event_id: uuid.UUID | None = None
         self._active_tab: str = "tab-project"
 
         self.theme = _DEFAULT_THEME
-
-        self.set_interval(5, self._check_iccs_staleness)
 
         logger.info("TUI started.")
         if not _project_exists(engine):
@@ -467,80 +332,6 @@ class AimbatTUI(App[None]):
             raise caught
 
     # ------------------------------------------------------------------
-    # ICCS lifecycle
-    # ------------------------------------------------------------------
-
-    def _create_iccs(self, *, is_retry: bool = False) -> None:
-        """Discard the existing ICCS instance and create a new one in a background worker.
-
-        ICCS construction reads waveform data, so it must not block the asyncio event loop.
-        Concurrent calls are ignored — only one worker runs at a time.
-
-        Args:
-            is_retry: Whether this call is the one-shot retry made in
-                response to `_iccs_retry_pending` after a previous failure.
-                A retry call is not itself allowed to re-arm
-                `_iccs_retry_pending`, so a persistently failing event gets
-                exactly one automatic retry rather than retrying forever.
-        """
-        if self._iccs_creating:
-            logger.debug(
-                "ICCS creation already in progress; skipping duplicate request."
-            )
-            return
-        self._iccs_creating = True
-        self._bound_iccs = None
-        self._iccs_retry_pending = False
-        self._worker_create_iccs(is_retry)
-
-    @work(thread=True)
-    def _worker_create_iccs(self, is_retry: bool = False) -> None:
-        """Create the ICCS instance for the current event without blocking the UI.
-
-        On success, hands the new `BoundICCS` instance to `_assign_iccs` on
-        the main thread. On failure, notifies the user and, unless this call
-        is itself a retry, arms `_iccs_retry_pending` for one further
-        automatic attempt.
-
-        Args:
-            is_retry: Whether this call is the one-shot retry after a
-                previous failure.
-        """
-        try:
-            with Session(engine) as session:
-                event = self._get_current_event(session)
-                bound_iccs = create_iccs_instance(session, event)
-        except (NoResultFound, RuntimeError):
-            logger.debug("ICCS worker: no event selected or no data; aborting.")
-            self.call_from_thread(setattr, self, "_iccs_creating", False)
-            return
-        except Exception as exc:
-            logger.exception(f"ICCS worker: unexpected error during creation: {exc}")
-            self.call_from_thread(
-                self.notify, f"ICCS init failed: {exc}", severity="error"
-            )
-            self.call_from_thread(setattr, self, "_iccs_creating", False)
-            if not is_retry:
-                # Give the staleness poller one retry attempt on the next tick.
-                self.call_from_thread(setattr, self, "_iccs_retry_pending", True)
-            return
-        logger.debug("ICCS worker: instance created successfully.")
-        self.call_from_thread(self._assign_iccs, bound_iccs)
-
-    def _assign_iccs(self, bound_iccs: BoundICCS) -> None:
-        """Store the newly created ICCS instance and refresh all panels.
-
-        Args:
-            bound_iccs: The instance created by `_worker_create_iccs`.
-        """
-        self._iccs_creating = False
-        self._bound_iccs = bound_iccs
-        logger.info("ICCS instance ready and assigned.")
-        # Rebuilding ICCS re-upserts iccs_cc per seismogram, which also feeds
-        # ProjectPanel's quality panel and station cc_mean/cc_sem column.
-        self.refresh_all()
-
-    # ------------------------------------------------------------------
     # Data refresh
     # ------------------------------------------------------------------
 
@@ -557,43 +348,9 @@ class AimbatTUI(App[None]):
         self._refresh_event_bar()
         self.query_one(ProjectPanel).refresh_data(self._current_event_id)
         self.query_one(SeismogramPanel).refresh_data(
-            self._current_event_id, self._bound_iccs
+            self._current_event_id, self._iccs_lifecycle.bound
         )
         self.query_one(SnapshotPanel).refresh_data(self._current_event_id)
-
-    def _check_iccs_staleness(self) -> None:
-        """Trigger ICCS recreation if the current event has been modified externally.
-
-        When ICCS creation previously failed (e.g. due to an invalid parameter set via
-        the CLI), retries once via `_iccs_retry_pending`, then waits for
-        `event.last_modified` to change again before retrying further — this avoids
-        retrying forever against a persistently failing event. On any detected
-        change the full UI is refreshed so panels reflect the new DB state immediately.
-        """
-        if self._current_event_id is None:
-            return
-        try:
-            with Session(engine) as session:
-                event = self._get_current_event(session)
-                last_modified = event.last_modified
-                stale = (
-                    self._bound_iccs.is_stale(event)
-                    if self._bound_iccs is not None
-                    else last_modified != self._iccs_last_modified_seen
-                )
-        except (NoResultFound, RuntimeError):
-            return
-        if stale:
-            logger.debug(
-                "ICCS staleness detected; recreating instance and refreshing UI."
-            )
-            self._iccs_last_modified_seen = last_modified
-            self._create_iccs()
-            self.refresh_all()
-        elif self._iccs_retry_pending:
-            logger.debug("Retrying ICCS creation after a previous failure.")
-            self._create_iccs(is_retry=True)
-            self.refresh_all()
 
     def _refresh_event_bar(self) -> None:
         """Update the status bar with the current event's time, location and ICCS status.
@@ -607,11 +364,11 @@ class AimbatTUI(App[None]):
             with Session(engine) as session:
                 event = self._get_current_event(session)
                 iccs_status = (
-                    " ● ICCS ready" if self._bound_iccs is not None else " ○ no ICCS"
+                    " ● ICCS ready" if self._iccs_lifecycle.ready else " ○ no ICCS"
                 )
                 time_str = fmt_timestamp(event.time) if event.time else "unknown"
-                lat = f"{event.latitude:.3f}°" if event.latitude is not None else "?"
-                lon = f"{event.longitude:.3f}°" if event.longitude is not None else "?"
+                lat = f"{event.latitude:.3f}°"
+                lon = f"{event.longitude:.3f}°"
                 modified = (
                     f"  modified: {fmt_timestamp(event.last_modified)}"
                     if event.last_modified is not None
@@ -715,12 +472,7 @@ class AimbatTUI(App[None]):
         logger.debug(f"User toggled completed flag for event {item_id[:8]}.")
         try:
             with Session(engine) as session:
-                event = session.get(AimbatEvent, uuid.UUID(item_id))
-                if event is None:
-                    return
-                event.parameters.completed = not event.parameters.completed
-                session.add(event)
-                session.commit()
+                toggle_event_completed(session, uuid.UUID(item_id))
             self.refresh_all()
             self.notify("Completed flag toggled", timeout=2)
         except Exception as exc:
@@ -771,12 +523,13 @@ class AimbatTUI(App[None]):
                     raise ValueError(f"Seismogram {item_id} not found")
                 new_value = not getattr(seis.parameters, param)
                 set_seismogram_parameter(session, seis_uuid, param, new_value)
-            if self._bound_iccs is not None:
-                for iccs_seis in self._bound_iccs.iccs.seismograms:
+            bound = self._iccs_lifecycle.bound
+            if bound is not None:
+                for iccs_seis in bound.iccs.seismograms:
                     if iccs_seis.extra.get("id") == seis_uuid:
                         setattr(iccs_seis, param, new_value)
-                        self._bound_iccs.iccs.clear_cache()
-                        self._bound_iccs.created_at = Timestamp.now("UTC")
+                        bound.iccs.clear_cache()
+                        bound.created_at = Timestamp.now("UTC")
                         break
             # Deliberately scoped: this only mutates the in-memory ICCS instance
             # and clears its cache, without re-upserting iccs_cc, so no other
@@ -784,7 +537,7 @@ class AimbatTUI(App[None]):
             # changes here. Also repeated once per seismogram during QC review,
             # so avoid the extra DB round trips a full refresh_all() would add.
             self.query_one(SeismogramPanel).refresh_data(
-                self._current_event_id, self._bound_iccs
+                self._current_event_id, self._iccs_lifecycle.bound
             )
             self.notify(f"{param} toggled", timeout=2)
         except Exception as exc:
@@ -830,7 +583,7 @@ class AimbatTUI(App[None]):
                         delete_event(session, uuid.UUID(item_id))
                     if self._current_event_id == uuid.UUID(item_id):
                         self._current_event_id = None
-                        self._bound_iccs = None
+                        self._iccs_lifecycle.clear()
                     self.refresh_all()
                     self.notify("Event deleted", timeout=2)
                 elif tab == "project-stations":
@@ -1009,26 +762,6 @@ class AimbatTUI(App[None]):
 
         self.push_screen(ActionMenuModal("Add Data", actions), on_type)
 
-    def _require_iccs(self) -> bool:
-        """Check that the ICCS instance is ready, showing a contextual warning otherwise.
-
-        Returns:
-            Whether the ICCS instance is ready to use.
-        """
-        if self._bound_iccs is not None:
-            return True
-        if self._current_event_id is not None:
-            self.notify(
-                "ICCS not ready — check event parameters (Parameters tab)",
-                severity="warning",
-            )
-        else:
-            self.notify(
-                "No event selected — select one on the Project tab",
-                severity="warning",
-            )
-        return False
-
     def action_open_interactive_tools(self) -> None:
         """Open the interactive tools menu and run the chosen tool."""
         if not self._require_iccs():
@@ -1045,7 +778,7 @@ class AimbatTUI(App[None]):
     def _run_tool(
         self, tool: str, context: bool, all_seis: bool, causal: bool | None
     ) -> None:
-        """Run an interactive tool from `_TOOL_REGISTRY` or `_CAUSAL_TOOL_REGISTRY`.
+        """Run an interactive tool from `TOOL_REGISTRY` or `CAUSAL_TOOL_REGISTRY`.
 
         Uses the long-lived ICCS instance so waveform data do not need to be
         reloaded. Suspends the TUI while the tool's matplotlib window is
@@ -1057,21 +790,20 @@ class AimbatTUI(App[None]):
                 the CC window.
             all_seis: Whether to include seismograms not currently selected.
             causal: Zero-phase/causal filter setting; only meaningful for
-                tools in `_CAUSAL_TOOL_REGISTRY`, otherwise `None`.
+                tools in `CAUSAL_TOOL_REGISTRY`, otherwise `None`.
         """
         logger.debug(
             f"User launched interactive tool '{tool}' "
             f"(context={context}, all_seis={all_seis}, causal={causal})."
         )
-        if self._bound_iccs is None:
+        bound = self._iccs_lifecycle.bound
+        if bound is None:
             self.notify("ICCS not ready — please wait", severity="warning")
             return
-        iccs = self._bound_iccs.iccs
-        is_causal_tool = tool in _CAUSAL_TOOL_REGISTRY
+        iccs = bound.iccs
+        is_causal_tool = tool in CAUSAL_TOOL_REGISTRY
         label = (
-            _CAUSAL_TOOL_REGISTRY[tool][0]
-            if is_causal_tool
-            else _TOOL_REGISTRY[tool][0]
+            CAUSAL_TOOL_REGISTRY[tool][0] if is_causal_tool else TOOL_REGISTRY[tool][0]
         )
 
         try:
@@ -1080,11 +812,11 @@ class AimbatTUI(App[None]):
                     event = self._get_current_event(session)
                     if is_causal_tool:
                         assert causal is not None
-                        _CAUSAL_TOOL_REGISTRY[tool][1](
+                        CAUSAL_TOOL_REGISTRY[tool][1](
                             session, event, iccs, context, all_seis, causal
                         )
                     else:
-                        _TOOL_REGISTRY[tool][1](session, event, iccs, context, all_seis)
+                        TOOL_REGISTRY[tool][1](session, event, iccs, context, all_seis)
         except Exception as exc:
             logger.exception(f"Interactive tool '{tool}' raised: {exc}")
             self.notify(str(exc), severity="error")
@@ -1092,7 +824,7 @@ class AimbatTUI(App[None]):
 
         # suspend() is synchronous, so the staleness poller cannot fire
         # between the session commit and this assignment.
-        self._bound_iccs.created_at = Timestamp.now("UTC")
+        bound.created_at = Timestamp.now("UTC")
         self.refresh_all()
         self.notify("Done", timeout=2)
 
@@ -1103,7 +835,7 @@ class AimbatTUI(App[None]):
 
         def on_result(result: tuple[str, bool, bool, bool] | None) -> None:
             if result is not None:
-                self._run_align_tool(self._bound_iccs, *result)
+                self._run_align_tool(self._iccs_lifecycle.bound, *result)
 
         self.push_screen(AlignModal(), on_result)
 

--- a/src/aimbat/_tui/modals.py
+++ b/src/aimbat/_tui/modals.py
@@ -18,12 +18,14 @@ from textual.screen import ModalScreen
 from textual.widgets import DataTable, Input, Label, Markdown, Static
 
 from aimbat._cli.common import CAUSAL_DEFAULTS
+from aimbat._tui._tools import CAUSAL_TOOL_REGISTRY, TOOL_REGISTRY
 from aimbat._tui._widgets import VimDataTable
 from aimbat._types import EventParameter
 from aimbat.core import set_event_parameter
 from aimbat.db import engine
 from aimbat.models import AimbatEvent
 from aimbat.models._parameters import AimbatEventParametersBase
+from aimbat.utils import format_validation_error
 
 if TYPE_CHECKING:
     from aimbat._tui._panels import RowAction
@@ -418,10 +420,7 @@ class ParametersModal(ModalScreen[bool]):
                     validate_iccs=True,
                 )  # type: ignore[call-overload]
         except ValidationError as exc:
-            msgs = "; ".join(
-                e["msg"].removeprefix("Value error, ") for e in exc.errors()
-            )
-            self.notify(msgs, severity="error")
+            self.notify(format_validation_error(exc), severity="error")
             return
         except Exception as exc:
             self.notify(str(exc), severity="error")
@@ -603,14 +602,8 @@ class SnapshotActionMenuModal(ModalScreen[tuple[str, bool, bool] | None]):
 # Interactive Tools modal
 # ---------------------------------------------------------------------------
 
-# Keep in sync with _TOOL_REGISTRY in app.py.
 _TOOLS: list[tuple[str, str]] = [
-    ("phase", "Phase arrival (t1)"),
-    ("window", "Time window"),
-    ("cc", "Min CC"),
-    ("bandpass", "Bandpass filter"),
-    ("stack", "Stack plot"),
-    ("image", "Matrix image"),
+    (key, label) for key, (label, _) in (CAUSAL_TOOL_REGISTRY | TOOL_REGISTRY).items()
 ]
 
 

--- a/src/aimbat/core/_event.py
+++ b/src/aimbat/core/_event.py
@@ -30,6 +30,7 @@ __all__ = [
     "get_events_using_station",
     "resolve_event",
     "set_event_parameter",
+    "toggle_event_completed",
     "dump_event_table",
     "dump_event_parameter_table",
     "dump_event_quality_table",
@@ -151,6 +152,35 @@ def get_events_using_station(
     logger.debug(f"Found {len(events)}.")
 
     return events
+
+
+def toggle_event_completed(session: Session, event_id: UUID) -> bool:
+    """Flip the `completed` flag on an event's parameters.
+
+    `completed` is excluded from the parameters hash used for snapshot
+    matching (it does not affect seismogram processing), so this does not
+    go through `set_event_parameter`'s snapshot-sync/MCCC-invalidation path.
+
+    Args:
+        session: Database session.
+        event_id: UUID of the event to toggle.
+
+    Returns:
+        The new value of the `completed` flag.
+
+    Raises:
+        NoResultFound: If no event with the given ID is found.
+    """
+    logger.debug(f"Toggling completed flag for event {event_id}.")
+
+    event = session.get(AimbatEvent, event_id)
+    if event is None:
+        raise NoResultFound(f"No AimbatEvent found with id: {event_id}.")
+
+    event.parameters.completed = not event.parameters.completed
+    session.add(event)
+    session.commit()
+    return event.parameters.completed
 
 
 def get_event_quality(session: Session, event_id: UUID) -> SeismogramQualityStats:

--- a/src/aimbat/core/_iccs.py
+++ b/src/aimbat/core/_iccs.py
@@ -8,7 +8,7 @@ the corresponding alignment/picking algorithms and persist their
 results.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from uuid import UUID, uuid4
 
 from pandas import Timestamp
@@ -26,7 +26,9 @@ from aimbat import settings
 from aimbat.logger import logger
 from aimbat.models import (
     AimbatEvent,
+    AimbatEventQuality,
     AimbatSeismogram,
+    AimbatSeismogramQuality,
     AimbatSnapshot,
 )
 from aimbat.models._parameters import (
@@ -38,6 +40,7 @@ from aimbat.utils import mean_and_sem, rel
 __all__ = [
     "BoundICCS",
     "CcStats",
+    "IccsLifecycle",
     "build_iccs_from_snapshot",
     "cc_stats",
     "clear_iccs_cache",
@@ -47,6 +50,7 @@ __all__ = [
     "run_mccc",
     "sync_iccs_parameters",
     "validate_iccs_construction",
+    "write_back_seismograms",
 ]
 
 
@@ -78,6 +82,103 @@ class BoundICCS:
         if event.last_modified is None:
             return False
         return event.last_modified > self.created_at
+
+
+@dataclass
+class IccsLifecycle:
+    """Framework-agnostic state and policy for keeping a `BoundICCS` up to date.
+
+    Owns the bound instance plus the bookkeeping needed to create it
+    asynchronously without blocking a UI thread: an in-progress guard so
+    overlapping creation attempts collapse into one, a one-shot retry flag
+    for recovering from a transient failure, and a fallback staleness check
+    (`event.last_modified`) for the window before any instance exists yet.
+
+    Callers own the actual I/O and threading (reading waveform data, running
+    in a background thread, marshalling results back to a UI thread) and
+    call the methods here only to record the outcome. See `AimbatTUI`'s
+    `_IccsLifecycleMixin` for the reference (Textual-based) caller.
+    """
+
+    bound: BoundICCS | None = None
+    retry_pending: bool = False
+    last_modified_seen: Timestamp | None = None
+    _creating: bool = field(default=False, repr=False, init=False)
+
+    @property
+    def ready(self) -> bool:
+        """Whether a bound ICCS instance is currently available."""
+        return self.bound is not None
+
+    def is_stale(self, event: AimbatEvent) -> bool:
+        """Return True if the bound instance (or lack of one) needs refreshing.
+
+        Delegates to `BoundICCS.is_stale` when an instance exists; otherwise
+        falls back to comparing `event.last_modified` against the value last
+        recorded via `note_checked`.
+
+        Args:
+            event: The event to check against.
+        """
+        if self.bound is not None:
+            return self.bound.is_stale(event)
+        return event.last_modified != self.last_modified_seen
+
+    def start_creating(self) -> bool:
+        """Begin a creation attempt, discarding any existing bound instance.
+
+        Returns:
+            False if a creation attempt is already in progress, in which
+            case the caller should skip starting a new one.
+        """
+        if self._creating:
+            return False
+        self._creating = True
+        self.bound = None
+        self.retry_pending = False
+        return True
+
+    def mark_aborted(self) -> None:
+        """Clear the in-progress flag without arming a retry.
+
+        Use when creation could not even be attempted (e.g. no event
+        selected) rather than when it was attempted and failed.
+        """
+        self._creating = False
+
+    def mark_failed(self, *, is_retry: bool) -> None:
+        """Record a failed creation attempt.
+
+        Args:
+            is_retry: Whether this attempt was itself the one-shot retry. A
+                retry is not allowed to re-arm itself, so a persistently
+                failing event gets exactly one automatic retry rather than
+                retrying forever.
+        """
+        self._creating = False
+        if not is_retry:
+            self.retry_pending = True
+
+    def assign(self, bound_iccs: BoundICCS) -> None:
+        """Record a newly created instance as ready."""
+        self._creating = False
+        self.bound = bound_iccs
+
+    def clear(self) -> None:
+        """Discard the bound instance without arming a retry.
+
+        Use when the instance is invalidated by something other than a
+        failed creation attempt (e.g. its event was deleted).
+        """
+        self.bound = None
+
+    def note_checked(self, last_modified: Timestamp | None) -> None:
+        """Record the `last_modified` value observed at a staleness check.
+
+        Only meaningful while `bound` is `None`; used by `is_stale` to
+        detect further changes before a new instance can be created.
+        """
+        self.last_modified_seen = last_modified
 
 
 @dataclass(frozen=True)
@@ -224,6 +325,17 @@ def create_iccs_instance(session: Session, event: AimbatEvent) -> BoundICCS:
     return bound
 
 
+def _find_seismogram_quality(
+    write_session: Session, seismogram_id: UUID
+) -> AimbatSeismogramQuality | None:
+    """Look up a seismogram's live quality row by seismogram ID, if one exists."""
+    return write_session.exec(
+        select(AimbatSeismogramQuality).where(
+            col(AimbatSeismogramQuality.seismogram_id) == seismogram_id
+        )
+    ).first()
+
+
 def _write_iccs_stats(event_id: UUID, iccs: ICCS) -> None:
     """Upsert per-seismogram ICCS CC values into the live quality table.
 
@@ -239,17 +351,12 @@ def _write_iccs_stats(event_id: UUID, iccs: ICCS) -> None:
         iccs: ICCS instance whose `ccs` values are written.
     """
     from aimbat.db import engine as _engine
-    from aimbat.models import AimbatSeismogramQuality
 
     logger.debug(f"Writing ICCS stats for event {event_id}.")
     with Session(_engine) as write_session:
         for iccs_seis, cc in zip(iccs.seismograms, iccs.ccs):
             seis_id = iccs_seis.extra["id"]
-            existing = write_session.exec(
-                select(AimbatSeismogramQuality).where(
-                    col(AimbatSeismogramQuality.seismogram_id) == seis_id
-                )
-            ).first()
+            existing = _find_seismogram_quality(write_session, seis_id)
             cc_val = max(-1.0, min(1.0, float(cc)))
             if existing is None:
                 row = AimbatSeismogramQuality(
@@ -283,7 +390,6 @@ def _write_mccc_quality(
             only the selected ones (`False`).
     """
     from aimbat.db import engine as _engine
-    from aimbat.models import AimbatEventQuality, AimbatSeismogramQuality
 
     used_seis = (
         iccs.seismograms
@@ -311,11 +417,7 @@ def _write_mccc_quality(
         # Clear MCCC fields for all seismograms first
         for iccs_seis in iccs.seismograms:
             seis_id = iccs_seis.extra["id"]
-            sq = write_session.exec(
-                select(AimbatSeismogramQuality).where(
-                    col(AimbatSeismogramQuality.seismogram_id) == seis_id
-                )
-            ).first()
+            sq = _find_seismogram_quality(write_session, seis_id)
             if sq is not None:
                 sq.mccc_error = None
                 sq.mccc_cc_mean = None
@@ -327,11 +429,7 @@ def _write_mccc_quality(
             used_seis, result.errors, result.cc_means, result.cc_stds
         ):
             seis_id = iccs_seis.extra["id"]
-            sq = write_session.exec(
-                select(AimbatSeismogramQuality).where(
-                    col(AimbatSeismogramQuality.seismogram_id) == seis_id
-                )
-            ).first()
+            sq = _find_seismogram_quality(write_session, seis_id)
             if sq is None:
                 sq = AimbatSeismogramQuality(
                     id=uuid4(),
@@ -481,7 +579,7 @@ def validate_iccs_construction(
     _build_iccs(event, parameters=parameters)
 
 
-def _write_back_seismograms(session: Session, iccs: ICCS) -> None:
+def write_back_seismograms(session: Session, iccs: ICCS) -> None:
     """Write t1, flip, and select from ICCS seismograms back to the database.
 
     Calls `session.commit()` after writing; any other pending changes on
@@ -557,7 +655,7 @@ def run_iccs(
     n_iter = len(result.convergence)
     status = "converged" if result.converged else "did not converge"
     logger.info(f"ICCS {status} after {n_iter} iterations.")
-    _write_back_seismograms(session, iccs)
+    write_back_seismograms(session, iccs)
     _write_iccs_stats(event.id, iccs)
     return result
 
@@ -586,7 +684,7 @@ def run_mccc(
         min_cc=event.parameters.mccc_min_cc,
         damping=event.parameters.mccc_damp,
     )
-    _write_back_seismograms(session, iccs)
+    write_back_seismograms(session, iccs)
     _write_iccs_stats(event.id, iccs)
     _write_mccc_quality(event.id, iccs, result, all_seismograms)
     return result

--- a/src/aimbat/core/_snapshot.py
+++ b/src/aimbat/core/_snapshot.py
@@ -11,7 +11,7 @@ recomputed (`sync_from_matching_hash`).
 
 import hashlib
 import json
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from typing import Any
 from uuid import UUID, uuid4
 
@@ -593,6 +593,49 @@ def dump_snapshot_quality_table(
     return data
 
 
+def _dump_snapshot_related_table(
+    session: Session,
+    model_name: str,
+    model: type[Any],
+    extract: Callable[[AimbatSnapshot], Sequence[Any]],
+    *,
+    event_id: UUID | None = None,
+    by_alias: bool = False,
+    exclude: set[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Dump one kind of record nested under snapshots as a list of dicts.
+
+    Shared by the `dump_*_snapshot_table` functions below, which each supply
+    the Pydantic model to serialise with and how to pull its records out of
+    one `AimbatSnapshot`.
+
+    Args:
+        session: Database session.
+        model_name: Name of the model being dumped, for the debug log line.
+        model: Pydantic model class of the records being dumped.
+        extract: Given one snapshot, returns the records of `model` it holds.
+        event_id: Event ID to filter snapshots by (if none is provided,
+            snapshots for all events are dumped).
+        by_alias: Whether to use serialization aliases for the field names in the output.
+        exclude: Set of field names to exclude from the output.
+
+    Returns:
+        List of dicts, one per record returned by `extract`, across all
+        matching snapshots.
+    """
+    logger.debug(f"Dumping {model_name} table to json.")
+
+    exclude_spec: dict[str, set] | None = {"__all__": exclude} if exclude else None
+
+    snapshots = get_snapshots(session, event_id)
+
+    adapter: TypeAdapter[Sequence[Any]] = TypeAdapter(Sequence[model])  # type: ignore[valid-type]
+    records = [record for s in snapshots for record in extract(s)]
+    return adapter.dump_python(
+        records, mode="json", by_alias=by_alias, exclude=exclude_spec
+    )
+
+
 def dump_event_parameter_snapshot_table(
     session: Session,
     event_id: UUID | None = None,
@@ -611,22 +654,15 @@ def dump_event_parameter_snapshot_table(
     Returns:
         List of dicts, one per event parameters snapshot.
     """
-    logger.debug("Dumping AimbatEventParametersSnapshot table to json.")
-
-    if exclude is not None:
-        exclude: dict[str, set] = {"__all__": exclude}  # type: ignore[no-redef]
-
-    snapshots = get_snapshots(session, event_id)
-
-    event_params_adapter: TypeAdapter[Sequence[AimbatEventParametersSnapshot]] = (
-        TypeAdapter(Sequence[AimbatEventParametersSnapshot])
+    return _dump_snapshot_related_table(
+        session,
+        "AimbatEventParametersSnapshot",
+        AimbatEventParametersSnapshot,
+        lambda s: [s.event_parameters_snapshot],
+        event_id=event_id,
+        by_alias=by_alias,
+        exclude=exclude,
     )
-    event_snaps = [s.event_parameters_snapshot for s in snapshots]
-    event_dicts = event_params_adapter.dump_python(
-        event_snaps, mode="json", by_alias=by_alias, exclude=exclude
-    )
-
-    return event_dicts
 
 
 def dump_seismogram_parameter_snapshot_table(
@@ -648,22 +684,15 @@ def dump_seismogram_parameter_snapshot_table(
         List of dicts, one per seismogram parameters snapshot across all
         matching snapshots.
     """
-    logger.debug("Dumping AimbatSeismogramParametersSnapshot table to json.")
-
-    if exclude is not None:
-        exclude: dict[str, set] = {"__all__": exclude}  # type: ignore[no-redef]
-
-    snapshots = get_snapshots(session, event_id)
-
-    seis_params_adapter: TypeAdapter[Sequence[AimbatSeismogramParametersSnapshot]] = (
-        TypeAdapter(Sequence[AimbatSeismogramParametersSnapshot])
+    return _dump_snapshot_related_table(
+        session,
+        "AimbatSeismogramParametersSnapshot",
+        AimbatSeismogramParametersSnapshot,
+        lambda s: s.seismogram_parameters_snapshots,
+        event_id=event_id,
+        by_alias=by_alias,
+        exclude=exclude,
     )
-    seis_snaps = [sp for s in snapshots for sp in s.seismogram_parameters_snapshots]
-    seis_dicts = seis_params_adapter.dump_python(
-        seis_snaps, mode="json", by_alias=by_alias, exclude=exclude
-    )
-
-    return seis_dicts
 
 
 def dump_event_quality_snapshot_table(
@@ -685,27 +714,17 @@ def dump_event_quality_snapshot_table(
         List of dicts, one per snapshot that has an event quality record
         (snapshots taken before any quality data existed are omitted).
     """
-    logger.debug("Dumping AimbatEventQualitySnapshot table to json.")
-
-    if exclude is not None:
-        exclude: dict[str, set] = {"__all__": exclude}  # type: ignore[no-redef]
-
-    snapshots = get_snapshots(session, event_id)
-
-    event_quality_adapter: TypeAdapter[Sequence[AimbatEventQualitySnapshot]] = (
-        TypeAdapter(Sequence[AimbatEventQualitySnapshot])
+    return _dump_snapshot_related_table(
+        session,
+        "AimbatEventQualitySnapshot",
+        AimbatEventQualitySnapshot,
+        lambda s: (
+            [s.event_quality_snapshot] if s.event_quality_snapshot is not None else []
+        ),
+        event_id=event_id,
+        by_alias=by_alias,
+        exclude=exclude,
     )
-    # Filter out snapshots that don't have event quality records.
-    event_quality_snaps = [
-        s.event_quality_snapshot
-        for s in snapshots
-        if s.event_quality_snapshot is not None
-    ]
-    event_quality_dicts = event_quality_adapter.dump_python(
-        event_quality_snaps, mode="json", by_alias=by_alias, exclude=exclude
-    )
-
-    return event_quality_dicts
 
 
 def dump_seismogram_quality_snapshot_table(
@@ -727,25 +746,15 @@ def dump_seismogram_quality_snapshot_table(
         List of dicts, one per seismogram quality record captured across all
         matching snapshots.
     """
-    logger.debug("Dumping AimbatSeismogramQualitySnapshot table to json.")
-
-    if exclude is not None:
-        exclude: dict[str, set] = {"__all__": exclude}  # type: ignore[no-redef]
-
-    snapshots = get_snapshots(session, event_id)
-
-    seis_quality_adapter: TypeAdapter[Sequence[AimbatSeismogramQualitySnapshot]] = (
-        TypeAdapter(Sequence[AimbatSeismogramQualitySnapshot])
+    return _dump_snapshot_related_table(
+        session,
+        "AimbatSeismogramQualitySnapshot",
+        AimbatSeismogramQualitySnapshot,
+        lambda s: s.seismogram_quality_snapshots,
+        event_id=event_id,
+        by_alias=by_alias,
+        exclude=exclude,
     )
-    # Collect all seismogram quality records from all snapshots.
-    seis_quality_snaps = [
-        sq for s in snapshots for sq in s.seismogram_quality_snapshots
-    ]
-    seis_quality_dicts = seis_quality_adapter.dump_python(
-        seis_quality_snaps, mode="json", by_alias=by_alias, exclude=exclude
-    )
-
-    return seis_quality_dicts
 
 
 def dump_snapshot_results(

--- a/src/aimbat/plot/_iccs.py
+++ b/src/aimbat/plot/_iccs.py
@@ -34,7 +34,7 @@ from pysmo.tools.iccs import (
 
 from aimbat._types import EventParameter
 from aimbat.core._event import set_event_parameter
-from aimbat.core._iccs import _write_back_seismograms
+from aimbat.core._iccs import write_back_seismograms
 from aimbat.logger import logger
 from aimbat.models import AimbatEvent
 
@@ -182,7 +182,7 @@ def update_pick(
     )
 
     if not return_fig:
-        _write_back_seismograms(session, iccs)
+        write_back_seismograms(session, iccs)
         return None
 
     logger.warning(_RETURN_FIG_WARNING)

--- a/src/aimbat/utils/_pydantic.py
+++ b/src/aimbat/utils/_pydantic.py
@@ -1,9 +1,25 @@
 from functools import lru_cache
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
-__all__ = ["get_title_map"]
+__all__ = ["format_validation_error", "get_title_map"]
+
+
+def format_validation_error(exc: ValidationError) -> str:
+    """Format a `ValidationError` as a short, semicolon-joined message.
+
+    Strips the redundant `"Value error, "` prefix Pydantic adds to custom
+    validator messages, so the result is fit for display without leaking
+    implementation detail.
+
+    Args:
+        exc: The validation error to format.
+
+    Returns:
+        A single-line, semicolon-joined summary of all validation errors.
+    """
+    return "; ".join(e["msg"].removeprefix("Value error, ") for e in exc.errors())
 
 
 @lru_cache(maxsize=None)

--- a/tests/functional/test_tui.py
+++ b/tests/functional/test_tui.py
@@ -6,6 +6,8 @@ monkeypatched to the test fixture's database:
 
 - ``aimbat.db.engine`` — the canonical engine attribute
 - ``aimbat._tui.app.engine`` — top-level import in the app module
+- ``aimbat._tui._iccs_lifecycle.engine`` — top-level import in the ICCS
+  lifecycle module
 - ``aimbat._tui._panels.engine`` — top-level import in the panels module
 - ``aimbat._tui.modals.engine`` — top-level import in the modals module
 - ``aimbat._tui._widgets.engine`` — top-level import in the widgets module
@@ -23,7 +25,9 @@ from sqlmodel import Session, select
 from textual.binding import Binding
 from textual.widgets import DataTable, Static, TabbedContent, TabPane
 
+import aimbat._tui._iccs_lifecycle
 import aimbat._tui._panels
+import aimbat._tui._tools
 import aimbat._tui._widgets
 import aimbat._tui.app
 import aimbat._tui.modals
@@ -56,6 +60,7 @@ def _patch_engine(monkeypatch: pytest.MonkeyPatch, engine: Engine) -> None:
     """Patch the engine in all TUI modules that import it at module level."""
     monkeypatch.setattr(aimbat.db, "engine", engine)
     monkeypatch.setattr(aimbat._tui.app, "engine", engine)
+    monkeypatch.setattr(aimbat._tui._iccs_lifecycle, "engine", engine)
     monkeypatch.setattr(aimbat._tui._panels, "engine", engine)
     monkeypatch.setattr(aimbat._tui.modals, "engine", engine)
     monkeypatch.setattr(aimbat._tui._widgets, "engine", engine)
@@ -373,8 +378,9 @@ class TestICCSStalenessRetry:
     """A failed ICCS creation gets exactly one automatic retry, not a retry storm.
 
     See `AimbatTUI._check_iccs_staleness` / `_create_iccs`: a fresh (non-retry)
-    failure sets `_iccs_retry_pending`, which the staleness poller consumes at
-    most once before falling silent again until `event.last_modified` changes.
+    failure sets `IccsLifecycle.retry_pending`, which the staleness poller
+    consumes at most once before falling silent again until
+    `event.last_modified` changes.
     """
 
     def test_retries_once_then_stops_on_persistent_failure(
@@ -390,7 +396,9 @@ class TestICCSStalenessRetry:
             call_count += 1
             raise ValueError("simulated persistent failure")
 
-        monkeypatch.setattr(aimbat._tui.app, "create_iccs_instance", _always_fails)
+        monkeypatch.setattr(
+            aimbat._tui._iccs_lifecycle, "create_iccs_instance", _always_fails
+        )
 
         async def _run() -> None:
             async with AimbatTUI().run_test(size=_TUI_SIZE) as pilot:
@@ -398,7 +406,7 @@ class TestICCSStalenessRetry:
                 # `on_mount` already kicked off its own `_create_iccs()` for
                 # this event-bearing fixture, with no event selected yet. Drain
                 # it first: otherwise it can still be in flight below, and the
-                # `_iccs_creating` guard silently skips the call this test
+                # `IccsLifecycle.start_creating` guard silently skips the call this test
                 # actually wants to observe.
                 await _wait_for_iccs_worker(app)
 
@@ -408,20 +416,20 @@ class TestICCSStalenessRetry:
                 app._current_event_id = event.id
                 # Mirror what `_check_iccs_staleness` records before a fresh
                 # attempt, so later polls see an unchanged `last_modified`.
-                app._iccs_last_modified_seen = event.last_modified
+                app._iccs_lifecycle.note_checked(event.last_modified)
 
                 app._create_iccs()
                 await _wait_for_iccs_worker(app)
                 assert call_count == 1
-                assert app._iccs_retry_pending is True
-                assert app._bound_iccs is None
+                assert app._iccs_lifecycle.retry_pending is True
+                assert app._iccs_lifecycle.bound is None
 
                 # The poller consumes the pending retry exactly once.
                 app._check_iccs_staleness()
                 await _wait_for_iccs_worker(app)
                 assert call_count == 2
-                assert app._iccs_retry_pending is False
-                assert app._bound_iccs is None
+                assert app._iccs_lifecycle.retry_pending is False
+                assert app._iccs_lifecycle.bound is None
 
                 # Further polls must not retry again — no infinite loop.
                 app._check_iccs_staleness()
@@ -446,7 +454,7 @@ class TestICCSStalenessRetry:
             return _real_create_iccs_instance(session, event)
 
         monkeypatch.setattr(
-            aimbat._tui.app, "create_iccs_instance", _fail_once_then_succeed
+            aimbat._tui._iccs_lifecycle, "create_iccs_instance", _fail_once_then_succeed
         )
 
         async def _run() -> None:
@@ -456,28 +464,192 @@ class TestICCSStalenessRetry:
                 # test_retries_once_then_stops_on_persistent_failure: drain
                 # `on_mount`'s own startup `_create_iccs()` call first, or it
                 # can still be in flight and make the call below a silent
-                # no-op via the `_iccs_creating` guard.
+                # no-op via the `IccsLifecycle.start_creating` guard.
                 await _wait_for_iccs_worker(app)
 
                 with Session(loaded_engine_from_file) as session:
                     event = session.exec(select(AimbatEvent)).first()
                 assert event is not None
                 app._current_event_id = event.id
-                app._iccs_last_modified_seen = event.last_modified
+                app._iccs_lifecycle.note_checked(event.last_modified)
 
                 app._create_iccs()
                 await _wait_for_iccs_worker(app)
                 assert attempts == 1
-                assert app._iccs_retry_pending is True
-                assert app._bound_iccs is None
+                assert app._iccs_lifecycle.retry_pending is True
+                assert app._iccs_lifecycle.bound is None
 
                 app._check_iccs_staleness()
                 await _wait_for_iccs_worker(app)
                 assert attempts == 2
-                assert app._iccs_retry_pending is False
-                assert app._bound_iccs is not None
+                assert app._iccs_lifecycle.retry_pending is False
+                assert app._iccs_lifecycle.bound is not None
 
         asyncio.run(_run())
+
+
+@pytest.mark.slow
+class TestIccsAssignmentRace:
+    """A worker completing for an event that is no longer current is discarded.
+
+    See `_IccsLifecycleMixin._assign_iccs`: if the selected event changes
+    (e.g. the bound event was deleted and a different one selected) while a
+    `_worker_create_iccs` call is still in flight, its result must not be
+    bound as if it were current — otherwise the app could end up "ready"
+    with an ICCS instance for the wrong (or deleted) event.
+    """
+
+    def test_stale_worker_result_is_discarded_and_current_event_retried(
+        self, loaded_engine_from_file: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A stale `_assign_iccs` call is dropped and the current event is (re)built."""
+        _patch_engine(monkeypatch, loaded_engine_from_file)
+
+        async def _run() -> None:
+            async with AimbatTUI().run_test(size=_TUI_SIZE) as pilot:
+                app = cast(AimbatTUI, pilot.app)
+                await _wait_for_iccs_worker(app)
+
+                with Session(loaded_engine_from_file) as session:
+                    events = session.exec(select(AimbatEvent)).all()
+                assert len(events) >= 2
+                stale_event, current_event = events[0], events[1]
+
+                with Session(loaded_engine_from_file) as session:
+                    stale_event_reloaded = session.get(AimbatEvent, stale_event.id)
+                    assert stale_event_reloaded is not None
+                    stale_bound = _real_create_iccs_instance(
+                        session, stale_event_reloaded
+                    )
+
+                # Simulate the user having switched to a different event
+                # while `stale_bound` was still being built in the
+                # background for `stale_event`.
+                app._current_event_id = current_event.id
+
+                app._assign_iccs(stale_bound)
+                assert app._iccs_lifecycle.bound is None
+
+                await _wait_for_iccs_worker(app)
+                assert app._iccs_lifecycle.bound is not None
+                assert app._iccs_lifecycle.bound.event_id == current_event.id
+
+        asyncio.run(_run())
+
+    def test_stale_worker_result_for_deleted_event_is_discarded(
+        self, loaded_engine_from_file: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A stale result is dropped and no retry is armed when nothing is selected."""
+        _patch_engine(monkeypatch, loaded_engine_from_file)
+
+        async def _run() -> None:
+            async with AimbatTUI().run_test(size=_TUI_SIZE) as pilot:
+                app = cast(AimbatTUI, pilot.app)
+                await _wait_for_iccs_worker(app)
+
+                with Session(loaded_engine_from_file) as session:
+                    event = session.exec(select(AimbatEvent)).first()
+                assert event is not None
+
+                with Session(loaded_engine_from_file) as session:
+                    event_reloaded = session.get(AimbatEvent, event.id)
+                    assert event_reloaded is not None
+                    stale_bound = _real_create_iccs_instance(session, event_reloaded)
+
+                # Simulate the event having been deleted (and none selected)
+                # while `stale_bound` was still being built.
+                app._current_event_id = None
+
+                app._assign_iccs(stale_bound)
+                await pilot.pause(delay=0.2)
+
+                assert app._iccs_lifecycle.bound is None
+                assert app._iccs_lifecycle.retry_pending is False
+
+        asyncio.run(_run())
+
+
+# ===========================================================================
+# _require_iccs — contextual "not ready" notification
+# ===========================================================================
+
+
+@pytest.mark.slow
+class TestRequireIccs:
+    """`_require_iccs` picks its warning based on whether an event is selected.
+
+    See `_IccsLifecycleMixin._require_iccs`: with no current event it points
+    the user at the Project tab; with an event selected but no bound ICCS
+    instance yet, it points at the Parameters tab instead.
+    """
+
+    def test_no_event_selected(
+        self, patched_engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With no current event, the notification directs to the Project tab."""
+        _patch_engine(monkeypatch, patched_engine)
+
+        notifications: list[tuple[str, str]] = []
+
+        async def _run() -> None:
+            async with AimbatTUI().run_test(size=_TUI_SIZE) as pilot:
+                await pilot.pause()
+                app = cast(AimbatTUI, pilot.app)
+                monkeypatch.setattr(
+                    app,
+                    "notify",
+                    lambda message, *, severity="information", **kwargs: (
+                        notifications.append((message, severity))
+                    ),
+                )
+                assert app._current_event_id is None
+
+                assert app._require_iccs() is False
+
+        asyncio.run(_run())
+
+        assert len(notifications) == 1
+        message, severity = notifications[0]
+        assert "no event selected" in message.lower()
+        assert "project" in message.lower()
+        assert severity == "warning"
+
+    def test_event_selected_but_iccs_not_ready(
+        self, loaded_engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With an event selected but no bound ICCS yet, it points at Parameters."""
+        _patch_engine(monkeypatch, loaded_engine)
+
+        notifications: list[tuple[str, str]] = []
+
+        async def _run() -> None:
+            async with AimbatTUI().run_test(size=_TUI_SIZE) as pilot:
+                await pilot.pause()
+                app = cast(AimbatTUI, pilot.app)
+                await _wait_for_iccs_worker(app)
+                monkeypatch.setattr(
+                    app,
+                    "notify",
+                    lambda message, *, severity="information", **kwargs: (
+                        notifications.append((message, severity))
+                    ),
+                )
+
+                with Session(loaded_engine) as session:
+                    event = session.exec(select(AimbatEvent)).first()
+                assert event is not None
+                app._current_event_id = event.id
+                assert app._iccs_lifecycle.ready is False
+
+                assert app._require_iccs() is False
+
+        asyncio.run(_run())
+
+        assert len(notifications) == 1
+        message, severity = notifications[0]
+        assert "iccs not ready" in message.lower()
+        assert "parameters" in message.lower()
+        assert severity == "warning"
 
 
 # ===========================================================================
@@ -1024,7 +1196,7 @@ class TestCausalZeroPhaseToggle:
         ) -> None:
             captured["causal"] = causal
 
-        monkeypatch.setattr(aimbat._tui.app, "update_pick", _fake_update_pick)
+        monkeypatch.setattr(aimbat._tui._tools, "update_pick", _fake_update_pick)
 
         async def _run() -> None:
             async with AimbatTUI().run_test(size=_TUI_SIZE) as pilot:
@@ -1036,7 +1208,7 @@ class TestCausalZeroPhaseToggle:
                 app._current_event_id = event.id
                 app._create_iccs()
                 await _wait_for_iccs_worker(app)
-                assert app._bound_iccs is not None
+                assert app._iccs_lifecycle.bound is not None
 
                 # "phase"'s causal default is True; pass the non-default
                 # value through explicitly.
@@ -1067,7 +1239,9 @@ class TestCausalZeroPhaseToggle:
         def _fake_update_bandpass(*args: object, **kwargs: object) -> None:
             calls.append(kwargs)
 
-        monkeypatch.setattr(aimbat._tui.app, "update_bandpass", _fake_update_bandpass)
+        monkeypatch.setattr(
+            aimbat._tui._tools, "update_bandpass", _fake_update_bandpass
+        )
 
         async def _run() -> None:
             async with AimbatTUI().run_test(size=_TUI_SIZE) as pilot:
@@ -1079,7 +1253,7 @@ class TestCausalZeroPhaseToggle:
                 app._current_event_id = event.id
                 app._create_iccs()
                 await _wait_for_iccs_worker(app)
-                assert app._bound_iccs is not None
+                assert app._iccs_lifecycle.bound is not None
 
                 app._run_tool("bandpass", True, False, None)
                 await pilot.pause()

--- a/tests/integration/core/test_event.py
+++ b/tests/integration/core/test_event.py
@@ -16,8 +16,9 @@ from aimbat.core import (
     get_completed_events,
     get_events_using_station,
     set_event_parameter,
+    toggle_event_completed,
 )
-from aimbat.models import AimbatEvent, AimbatStation
+from aimbat.models import AimbatEvent, AimbatEventQuality, AimbatStation
 
 # ===================================================================
 # Default event
@@ -230,6 +231,74 @@ class TestSetEventParameter:
             assert event is not None
             assert event.parameters.window_post == new_value
             assert event.last_modified is not None
+
+
+class TestToggleEventCompleted:
+    """Tests for flipping an event's `completed` flag."""
+
+    def test_toggle_flips_false_to_true(self, loaded_session: Session) -> None:
+        """Verifies the flag flips and the new value is returned.
+
+        Args:
+            loaded_session: The database session.
+        """
+        event = loaded_session.exec(select(AimbatEvent)).first()
+        assert event is not None
+        assert event.parameters.completed is False
+
+        result = toggle_event_completed(loaded_session, event.id)
+
+        assert result is True
+        assert event.parameters.completed is True
+
+    def test_toggle_twice_returns_to_original(self, loaded_session: Session) -> None:
+        """Verifies a second toggle flips the flag back.
+
+        Args:
+            loaded_session: The database session.
+        """
+        event = loaded_session.exec(select(AimbatEvent)).first()
+        assert event is not None
+
+        toggle_event_completed(loaded_session, event.id)
+        result = toggle_event_completed(loaded_session, event.id)
+
+        assert result is False
+        assert event.parameters.completed is False
+
+    def test_toggle_not_found_raises(self, loaded_session: Session) -> None:
+        """Verifies a missing event ID raises NoResultFound.
+
+        Args:
+            loaded_session: The database session.
+        """
+        with pytest.raises(NoResultFound):
+            toggle_event_completed(loaded_session, uuid.uuid4())
+
+    def test_toggle_does_not_clear_mccc_quality(self, loaded_session: Session) -> None:
+        """Verifies toggling `completed` leaves MCCC quality untouched.
+
+        `completed` is deliberately excluded from the parameters hash used
+        for snapshot matching (see `compute_parameters_hash`), so this must
+        not go through `set_event_parameter`'s snapshot-sync/MCCC-invalidation
+        path the way real processing parameters do.
+
+        Args:
+            loaded_session: The database session.
+        """
+        event = loaded_session.exec(select(AimbatEvent)).first()
+        assert event is not None
+        rmse = Timedelta(milliseconds=1)
+        loaded_session.add(
+            AimbatEventQuality(id=uuid.uuid4(), event_id=event.id, mccc_rmse=rmse)
+        )
+        loaded_session.commit()
+
+        toggle_event_completed(loaded_session, event.id)
+
+        loaded_session.refresh(event)
+        assert event.quality is not None
+        assert event.quality.mccc_rmse == rmse
 
 
 # ===================================================================

--- a/tests/unit/core/test_iccs_lifecycle.py
+++ b/tests/unit/core/test_iccs_lifecycle.py
@@ -1,0 +1,191 @@
+"""Unit tests for `aimbat.core._iccs.IccsLifecycle`.
+
+Pure state-machine tests: `IccsLifecycle` owns no I/O or threading, so these
+run without a database session or SQLModel persistence, unlike most of
+`tests/integration/core/`.
+"""
+
+import uuid
+from typing import cast
+
+from pandas import Timedelta, Timestamp
+
+from pysmo.tools.iccs import ICCS
+
+from aimbat.core._iccs import BoundICCS, IccsLifecycle
+from aimbat.models import AimbatEvent
+
+
+def _make_event(
+    *, event_id: uuid.UUID | None = None, last_modified: Timestamp | None = None
+) -> AimbatEvent:
+    """Build a detached AimbatEvent with just the fields IccsLifecycle reads."""
+    return AimbatEvent(
+        id=event_id or uuid.uuid4(),
+        time=Timestamp("2020-01-01T00:00:00", tz="UTC"),
+        latitude=0.0,
+        longitude=0.0,
+        last_modified=last_modified,
+    )
+
+
+def _make_bound(event_id: uuid.UUID, created_at: Timestamp) -> BoundICCS:
+    """Build a BoundICCS with a dummy ICCS payload — is_stale never touches it."""
+    return BoundICCS(
+        iccs=cast(ICCS, object()), event_id=event_id, created_at=created_at
+    )
+
+
+class TestReady:
+    """Tests for IccsLifecycle.ready."""
+
+    def test_not_ready_initially(self) -> None:
+        """A fresh lifecycle has no bound instance."""
+        assert IccsLifecycle().ready is False
+
+    def test_ready_once_assigned(self) -> None:
+        """Ready becomes True once an instance is assigned."""
+        lifecycle = IccsLifecycle()
+        lifecycle.assign(_make_bound(uuid.uuid4(), Timestamp.now("UTC")))
+        assert lifecycle.ready is True
+
+
+class TestIsStale:
+    """Tests for IccsLifecycle.is_stale."""
+
+    def test_no_bound_instance_falls_back_to_last_modified_seen(self) -> None:
+        """With no bound instance, staleness compares against note_checked's value."""
+        lifecycle = IccsLifecycle()
+        event = _make_event(last_modified=Timestamp("2020-01-01T00:00:00", tz="UTC"))
+
+        # Nothing recorded yet -> considered stale.
+        assert lifecycle.is_stale(event) is True
+
+        lifecycle.note_checked(event.last_modified)
+        assert lifecycle.is_stale(event) is False
+
+        event.last_modified = Timestamp("2020-01-02T00:00:00", tz="UTC")
+        assert lifecycle.is_stale(event) is True
+
+    def test_bound_instance_delegates_to_bound_is_stale(self) -> None:
+        """With a bound instance, staleness delegates to BoundICCS.is_stale."""
+        event_id = uuid.uuid4()
+        created_at = Timestamp("2020-01-01T00:00:00", tz="UTC")
+        lifecycle = IccsLifecycle(bound=_make_bound(event_id, created_at))
+
+        fresh_event = _make_event(event_id=event_id, last_modified=None)
+        assert lifecycle.is_stale(fresh_event) is False
+
+        modified_event = _make_event(
+            event_id=event_id, last_modified=created_at + Timedelta(seconds=1)
+        )
+        assert lifecycle.is_stale(modified_event) is True
+
+        other_event = _make_event(event_id=uuid.uuid4())
+        assert lifecycle.is_stale(other_event) is True
+
+
+class TestStartCreating:
+    """Tests for IccsLifecycle.start_creating."""
+
+    def test_returns_true_and_resets_state(self) -> None:
+        """Starting a fresh attempt discards any bound instance and pending retry."""
+        lifecycle = IccsLifecycle(bound=_make_bound(uuid.uuid4(), Timestamp.now("UTC")))
+        lifecycle.retry_pending = True
+
+        assert lifecycle.start_creating() is True
+        assert lifecycle.bound is None
+        assert lifecycle.retry_pending is False
+
+    def test_returns_false_while_already_creating(self) -> None:
+        """A second concurrent attempt is rejected while one is in progress."""
+        lifecycle = IccsLifecycle()
+        assert lifecycle.start_creating() is True
+        assert lifecycle.start_creating() is False
+
+
+class TestMarkAborted:
+    """Tests for IccsLifecycle.mark_aborted."""
+
+    def test_clears_creating_without_arming_retry(self) -> None:
+        """Aborting (e.g. no event selected) does not schedule a retry."""
+        lifecycle = IccsLifecycle()
+        lifecycle.start_creating()
+
+        lifecycle.mark_aborted()
+
+        assert lifecycle.retry_pending is False
+        assert lifecycle.start_creating() is True
+
+
+class TestMarkFailed:
+    """Tests for IccsLifecycle.mark_failed."""
+
+    def test_fresh_failure_arms_one_shot_retry(self) -> None:
+        """A failure that wasn't itself a retry arms exactly one retry."""
+        lifecycle = IccsLifecycle()
+        lifecycle.start_creating()
+
+        lifecycle.mark_failed(is_retry=False)
+
+        assert lifecycle.retry_pending is True
+
+    def test_retry_failure_does_not_rearm(self) -> None:
+        """A failed retry attempt does not schedule another retry."""
+        lifecycle = IccsLifecycle()
+        lifecycle.start_creating()
+
+        lifecycle.mark_failed(is_retry=True)
+
+        assert lifecycle.retry_pending is False
+
+    def test_clears_creating_guard(self) -> None:
+        """A failed attempt allows a new attempt to start."""
+        lifecycle = IccsLifecycle()
+        lifecycle.start_creating()
+
+        lifecycle.mark_failed(is_retry=False)
+
+        assert lifecycle.start_creating() is True
+
+
+class TestAssign:
+    """Tests for IccsLifecycle.assign."""
+
+    def test_stores_bound_and_clears_creating(self) -> None:
+        """A successful creation stores the instance and clears the in-progress guard."""
+        lifecycle = IccsLifecycle()
+        lifecycle.start_creating()
+        bound = _make_bound(uuid.uuid4(), Timestamp.now("UTC"))
+
+        lifecycle.assign(bound)
+
+        assert lifecycle.bound is bound
+        assert lifecycle.ready is True
+        assert lifecycle.start_creating() is True
+
+
+class TestClear:
+    """Tests for IccsLifecycle.clear."""
+
+    def test_discards_bound_without_arming_retry(self) -> None:
+        """Clearing (e.g. the bound event was deleted) does not schedule a retry."""
+        lifecycle = IccsLifecycle(bound=_make_bound(uuid.uuid4(), Timestamp.now("UTC")))
+
+        lifecycle.clear()
+
+        assert lifecycle.bound is None
+        assert lifecycle.retry_pending is False
+
+
+class TestNoteChecked:
+    """Tests for IccsLifecycle.note_checked."""
+
+    def test_updates_last_modified_seen(self) -> None:
+        """The observed timestamp is recorded verbatim."""
+        lifecycle = IccsLifecycle()
+        ts = Timestamp("2020-01-01T00:00:00", tz="UTC")
+
+        lifecycle.note_checked(ts)
+
+        assert lifecycle.last_modified_seen == ts

--- a/uv.lock
+++ b/uv.lock
@@ -1536,36 +1536,6 @@ wheels = [
 ]
 
 [[package]]
-name = "numpy-typing-compat"
-version = "20260602.2.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/08/db/5cd1d99caea4bf39fd477686ded4b9b70dff3c7673b5d84ef2d96a4f5aab/numpy_typing_compat-20260602.2.5.tar.gz", hash = "sha256:1885a678e9a24564839ed5d1711c0031735fb7de7f0b5ed88d550e5d45a8d4f9", size = 4593, upload-time = "2026-06-02T15:52:39.331Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/a4/9376b38b7387a0296b1f626b966e5503578625c9673777db1b45bf70acb0/numpy_typing_compat-20260602.2.5-py3-none-any.whl", hash = "sha256:21ba7757c8924d359a9ed3ab2163c282a70983ae64498fdba6d1892a6641c8b1", size = 5881, upload-time = "2026-06-02T15:52:34.167Z" },
-]
-
-[[package]]
-name = "optype"
-version = "0.18.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/99/51/51dc9b1009e020f44703933d4d1ee3429c647c026ce7806b37ee2b257998/optype-0.18.0.tar.gz", hash = "sha256:ea10dee61b15ca299ed0d97025d362585c4dfc5481159bb999a1d0d414bbcb04", size = 59967, upload-time = "2026-06-07T22:13:17.534Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/91/2b064a117cb2593bc3eb04ee994134ca2a6bf2162c92961769947e3258cc/optype-0.18.0-py3-none-any.whl", hash = "sha256:91822ed8516e7a4f225ba53d30f291776c35f31553fb952d7cda98286679c5a6", size = 73410, upload-time = "2026-06-07T22:13:16.324Z" },
-]
-
-[package.optional-dependencies]
-numpy = [
-    { name = "numpy" },
-    { name = "numpy-typing-compat" },
-]
-
-[[package]]
 name = "packaging"
 version = "26.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1693,11 +1663,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.11.3"
+version = "4.11.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b8/d7/e7bfbc86e9f99ff7807e24de7703f032e9c9ba80bb355cf26e0e9bc5a75e/platformdirs-4.11.3.tar.gz", hash = "sha256:66a73d38a849810252df809a3d8bcbda8e26f6c189920e7535ad608a48dbb5ab", size = 33050, upload-time = "2026-08-13T22:43:27.52Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/bb/ebc6636e1ae41314f796ebb7215fd28febb45f9aac72f2b04cb74b5071dc/platformdirs-4.11.4.tar.gz", hash = "sha256:f3373be828247211d0febabea97e238c3dfde8a60b3c90c32756fb52cb21556d", size = 34079, upload-time = "2026-08-24T14:53:49.676Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/a9/c34aebedd3a4c9afe5101b1b8713710b3fec18087c8a36c35d2f909861bd/platformdirs-4.11.3-py3-none-any.whl", hash = "sha256:5ed065d443751de711da036041a7a214122efc4a4de393b3f4137ba5576540e7", size = 23491, upload-time = "2026-08-13T22:43:26.121Z" },
+    { url = "https://files.pythonhosted.org/packages/28/be/0ff05fcd2938fb58ad9219bd54135968342d214737e012d62d43f06a2dd6/platformdirs-4.11.4-py3-none-any.whl", hash = "sha256:e34ff91a24bcddc6d939b878bdf3f5c437c9c46fe9e212b1bf455fdf1ee57586", size = 23741, upload-time = "2026-08-24T14:53:48.406Z" },
 ]
 
 [[package]]
@@ -2017,8 +1987,8 @@ wheels = [
 
 [[package]]
 name = "pysmo"
-version = "1.0.0.dev107+g3993faff3"
-source = { git = "https://github.com/pysmo/pysmo?rev=master#3993faff31baa26e60c35ac3d6f3159dd8585f46" }
+version = "1.0.0.dev118+gbc530bdd9"
+source = { git = "https://github.com/pysmo/pysmo?rev=master#bc530bdd92703d8299fcc2db019709b3abc233ab" }
 dependencies = [
     { name = "annotated-types" },
     { name = "attrs" },
@@ -2026,10 +1996,8 @@ dependencies = [
     { name = "matplotlib" },
     { name = "numpy" },
     { name = "pandas" },
-    { name = "pandas-stubs" },
     { name = "pyproj" },
     { name = "scipy" },
-    { name = "scipy-stubs" },
     { name = "urllib3" },
 ]
 
@@ -2295,18 +2263,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/2e/f97a666d362fee68b18f41c9c30ed502ca5c98b549749bfcb52a8b74d1eb/scipy-1.18.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:11c423f1049c5755ad4409af52a9ada1cff96fe9b50795d4af3619f292901239", size = 37525424, upload-time = "2026-08-21T23:26:56.751Z" },
     { url = "https://files.pythonhosted.org/packages/ca/d5/a9e765a84654ebba8479a1fd1b059ced1af72b168a3b2a3a46540ea38d20/scipy-1.18.1-cp314-cp314t-win_amd64.whl", hash = "sha256:c24acac1e18912761c4700239bbc1fd32f615af690f1584d49b35859be51324d", size = 37416961, upload-time = "2026-08-21T23:27:01.546Z" },
     { url = "https://files.pythonhosted.org/packages/ee/16/e79e0d1c63ef698879d85439d37e9fb434e3b804e506a6991038d086ebd9/scipy-1.18.1-cp314-cp314t-win_arm64.whl", hash = "sha256:9f2897bf7737392ad0d5213ea7b6add72a4edf5679b3153106aeb88b6507b3b9", size = 25331848, upload-time = "2026-08-21T23:27:05.884Z" },
-]
-
-[[package]]
-name = "scipy-stubs"
-version = "1.18.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "optype", extra = ["numpy"] },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/99/02c608a58cf99774c577f22e457427f87c8e608652c5de95178daa003e1f/scipy_stubs-1.18.1.0.tar.gz", hash = "sha256:87bec0df883cd9cd6b7dc4c74a33362cf550e9cad679643a29a886ab2b438ddc", size = 448822, upload-time = "2026-08-22T09:22:52.944Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/11/263ced30149fbede00614a11f01de792842d3636b5a9e3abfee34e764a0e/scipy_stubs-1.18.1.0-py3-none-any.whl", hash = "sha256:fc1f00da3eb6bf1adf2138774b5e6a91dcf7c77039ff199577dc47929c10793e", size = 653731, upload-time = "2026-08-22T09:22:51.43Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Extract the tool-dispatch registry into _tui/_tools.py; modals.py's hand-synced tool list now derives from it instead of duplicating it.
- Extract ICCS creation/staleness/retry lifecycle into a Textual mixin (_tui/_iccs_lifecycle.py) backed by a new framework-agnostic IccsLifecycle state machine in core/_iccs.py, positioned for reuse by a future non-TUI frontend.
- Route _toggle_event_completed through a new core.toggle_event_completed instead of mutating the DB directly from the TUI, matching every sibling handler; deliberately bypasses set_event_parameter since `completed` is excluded from the snapshot-matching parameters hash.
- Extract ParametersModal's ValidationError formatting into utils.format_validation_error.
- Promote core._iccs._write_back_seismograms to write_back_seismograms so plot/_iccs.py no longer reaches across the core/plot privacy boundary.
- Dedupe the four dump_*_snapshot_table functions in core/_snapshot.py behind a shared _dump_snapshot_related_table helper, and the find-or-create query in core/_iccs.py's quality-writing functions behind _find_seismogram_quality.

Adds unit coverage for IccsLifecycle and integration coverage for toggle_event_completed.

<!-- readthedocs-preview aimbat start -->
----
📚 Documentation preview 📚: https://aimbat--249.org.readthedocs.build/en/249/

<!-- readthedocs-preview aimbat end -->