### PR TITLE
feat(data): add near-duplicate event detection to `data add`

### DIFF
--- a/docs/first-steps/installation.md
+++ b/docs/first-steps/installation.md
@@ -59,7 +59,7 @@ Usage: aimbat COMMAND
 ...
 ```
 
-!!! tip
+!!! tip "`aimbat` command not found"
 
     If your shell cannot find the `aimbat` command, add `~/.local/bin` to your
     `PATH` by running `#!bash uv tool update-shell`.

--- a/docs/first-steps/workflow.md
+++ b/docs/first-steps/workflow.md
@@ -74,7 +74,7 @@ but *all* seismograms are cross-correlated against the stack regardless of their
 `select` status. A deselected seismogram can therefore recover automatically if
 parameter changes bring it into alignment.
 
-!!! tip
+!!! tip "Watch for rogue seismograms"
 
     If a seismogram drifts far from the stack (large difference between initial and
     revised pick across iterations), consider deleting it from the project. Rogue
@@ -91,11 +91,11 @@ MCCC has one optional flag:
     state, which is useful when you want timing estimates for all stations even
     if some were excluded from the ICCS stack.
 
-!!! warning
+!!! warning "Use `--all` with care"
 
-    Use `--all` with care: deselected seismograms are typically excluded because
-    they are noisy or misaligned, and including them may degrade the inversion
-    for the rest of the array.
+    Deselected seismograms are typically excluded because they are noisy or
+    misaligned, and including them may degrade the inversion for the rest of
+    the array.
 
 [^1]: VanDecar, J. C., and R. S. Crosson. "Determination of Teleseismic Relative
     Phase Arrival Times Using Multi-Channel Cross-Correlation and Least Squares."

--- a/docs/usage/data.md
+++ b/docs/usage/data.md
@@ -74,17 +74,54 @@ aimbat data add *.sac          # second run: no-op, all files already known
 ### Event matching relies on exact time equality
 
 AIMBAT links a SAC file to an existing event only if its origin time is
-**exactly** equal to that event's stored time — otherwise it creates a new,
-separate event. The classic (v6) SAC header stores event time as a 32-bit float,
-which does not always round-trip identically across files, so this can silently
-fragment one real event into many.
+**exactly** equal to that event's stored time — accurate to the microsecond,
+which is the precision AIMBAT stores timestamps at — otherwise it does not
+reuse that event.
+
+A new origin time that nearly, but not exactly, matches an existing event's
+time is not silently turned into a second event, though: it is flagged as a
+possible near-duplicate. How close counts as "near" is controlled by
+`event_duplicate_tolerance` and `event_duplicate_raise_tolerance` (see
+[Aimbat Defaults](defaults.md)):
+
+- Within `event_duplicate_tolerance` (default 0.1 s), importing raises an
+  error — or, during `--dry-run`, is reported as a warning instead — since a
+  gap this small is usually timestamp precision loss upstream (e.g. the
+  classic v6 SAC header's 32-bit float `o` field, which does not always
+  round-trip identically across files) rather than a genuinely distinct
+  event.
+- Beyond that but within `event_duplicate_raise_tolerance` (default 2 s),
+  importing always raises, even during `--dry-run`, since a gap this size
+  usually signals an actual timing problem in the source data worth
+  investigating before import.
+- Beyond `event_duplicate_raise_tolerance`, the new origin time is treated as
+  a genuinely independent event, with no warning.
+
+This check runs against every event AIMBAT already knows about when a file is
+processed, including other events created earlier in the same `data add`
+invocation, not only events already in the project beforehand. Resolving a
+flagged conflict is always first-wins: re-run with `--use-event <ID>` to link
+the new file to the pre-existing event's stored time and location exactly as
+they already are — it never merges, averages, or recomputes from the new
+file.
 
 !!! warning "Use SAC header version 7, or provide the event explicitly"
 
-    Write files with `NVHDR=7` — its double-precision footer avoids the rounding
-    issue. Otherwise, supply the event once from a JSON file and link every SAC file
-    to it with `--use-event <ID>`, bypassing SAC-derived time matching entirely; see
+    Write files with `NVHDR=7` — its double-precision footer avoids the classic
+    header's rounding issue. Otherwise, supply the event once from a JSON file
+    and link every SAC file to it with `--use-event <ID>`, bypassing
+    SAC-derived time matching entirely; see
     [Supplying a missing event](#supplying-a-missing-event).
+
+!!! note "Turning near-duplicate detection off"
+
+    `event_duplicate_strict` (see [Aimbat Defaults](defaults.md)) skips both
+    tolerance checks above, leaving only the exact-time match: any gap of a
+    microsecond or more, however small, then creates a fully independent
+    event with no warning at all. Use it only when the source data are
+    trusted to already be free of timing problems at that precision — e.g. a
+    catalogue known to contain legitimately close, but genuinely distinct,
+    events such as an aftershock swarm.
 
 ### Selecting subsets
 
@@ -104,6 +141,23 @@ Use `--dry-run` to see what would be added without touching the database:
 ```bash
 aimbat data add --dry-run *.sac
 ```
+
+It prints a summary of which stations, events, and seismograms would be newly
+created versus already known, and — because
+[near-duplicate events are flagged rather than silently created](#event-matching-relies-on-exact-time-equality)
+— any near-duplicate warnings that a real run would otherwise raise on
+instead. That makes `--dry-run` worth reaching for as routine practice before
+importing a new batch, not just to preview record counts: catching a flagged
+near-duplicate here means resolving it up front with `--use-event <ID>`,
+rather than hitting it partway through a real import — which aborts the
+whole batch and rolls back everything already added in that call, dry-run or
+not.
+
+`--dry-run` only softens the outcome for gaps within
+`event_duplicate_tolerance`, the tighter of the two bands. A gap in the
+wider `event_duplicate_raise_tolerance` band still raises even during
+`--dry-run`, since that band signals a likely data problem meant to be
+investigated before import, not deferred past it.
 
 ### Initial picks
 
@@ -228,7 +282,7 @@ In the TUI, select any row in the **Seismograms** tab and press `Enter` to open
 the action menu, which includes a delete option. Events and stations can be
 deleted from the **Project** tab in the same way.
 
-!!! note
+!!! note "The file on disk is never touched"
 
     Deleting a seismogram from AIMBAT never touches the underlying file on disk —
     only the database record and its link to the waveform source are removed.

--- a/docs/usage/defaults.md
+++ b/docs/usage/defaults.md
@@ -15,7 +15,7 @@ be overridden on a per-project basis (in order of precedence):
 
 --8<-- "docs/usage/defaults-table.md"
 
-!!! tip
+!!! tip "Viewing the settings in effect"
 
     To view the settings currently in use, run `aimbat utils settings`.
 

--- a/docs/usage/event-selection.md
+++ b/docs/usage/event-selection.md
@@ -62,7 +62,7 @@ aimbat snapshot create "post-ICCS"
 The shell prompt also reflects this ID when set. To clear it, unset the
 variable: `unset DEFAULT_EVENT_ID`.
 
-!!! note
+!!! note "Not an AIMBAT setting"
 
     `DEFAULT_EVENT_ID` is a plain shell environment variable consumed directly by
     the CLI argument parser. It is **not** an AIMBAT setting: it has no `AIMBAT_`

--- a/src/aimbat/_cli/data.py
+++ b/src/aimbat/_cli/data.py
@@ -25,6 +25,22 @@ aimbat event list          # list events created from SAC headers
 Re-adding a data source that is already in the project is safe — existing
 records are reused rather than duplicated.
 
+Near-duplicate events — two files whose origin times differ by only a
+sliver, most often from precision loss upstream (e.g. SAC's `o`-header
+32-bit float) rather than genuinely distinct events — are flagged rather
+than silently merged. Resolving a flagged conflict is always first-wins:
+`--use-event <uuid>` links the new data to the pre-existing event's stored
+time and location exactly as they already are, it never merges, averages,
+or recomputes from the new file. Detection is controlled by
+`event_duplicate_tolerance` (below this, a gap is assumed to be ordinary
+precision noise), `event_duplicate_raise_tolerance` (above
+`event_duplicate_tolerance` but below this, a gap is treated as a likely
+data problem and always raises, even during `--dry-run`), and
+`event_duplicate_strict` (skips both checks entirely — with it set, events
+are only ever merged on an exact origin-time match, which is itself only
+accurate to the microsecond AIMBAT stores timestamps at, so any gap of a
+microsecond or more silently creates a second event).
+
 `data add` automatically creates a snapshot for each event that received new
 seismogram data, so there is no need to run `snapshot create` right after
 ingestion (pass `--no-snapshot` to opt out for a given invocation). Use
@@ -63,15 +79,17 @@ app = App(name="data", help=__doc__, help_format="markdown")
 
 def _print_dry_run_results(
     added_datasources: Sequence[AimbatDataSource],
-    existing_station_ids: set,
-    existing_event_ids: set,
-    existing_seismogram_ids: set,
+    existing_station_ids: set[uuid.UUID],
+    existing_event_ids: set[uuid.UUID],
+    existing_seismogram_ids: set[uuid.UUID],
+    duplicate_warnings: Sequence[str],
 ) -> None:
     """Print a summary table showing which entities were added vs skipped."""
     from pydantic import BaseModel, Field
     from rich.console import Console
 
     from .common import json_to_table
+    from .common._decorators import _print_warning
 
     class _DryRunRow(BaseModel):
         source: str = Field(title="Source")
@@ -110,6 +128,9 @@ def _print_dry_run_results(
         f"{new_seismograms} seismogram(s) added, "
         f"{len(added_datasources) - new_seismograms} skipped."
     )
+
+    for message in duplicate_warnings:
+        _print_warning(message)
 
 
 def _create_snapshots_for_touched_events(
@@ -219,6 +240,11 @@ def cli_data_add(
     Use `--dry-run` to preview what would be added without touching the
     database. Use `--no-snapshot` to skip the automatic post-ingestion
     snapshot for this invocation.
+
+    Note `--dry-run` can still raise rather than produce a clean preview: an
+    "ambiguous gap" near-duplicate event (see the module help above) is
+    flagged as an error unconditionally, since it usually signals a data
+    problem worth stopping for even during a preview.
     """
     from rich.progress import Progress
 
@@ -237,6 +263,7 @@ def cli_data_add(
                 existing_station_ids,
                 existing_event_ids,
                 existing_seismogram_ids,
+                duplicate_warnings,
             ) = add_data_to_project(
                 session,
                 data_sources,
@@ -253,6 +280,7 @@ def cli_data_add(
                 existing_station_ids,
                 existing_event_ids,
                 existing_seismogram_ids,
+                duplicate_warnings,
             )
         elif auto_snapshot:
             _create_snapshots_for_touched_events(

--- a/src/aimbat/_config.py
+++ b/src/aimbat/_config.py
@@ -60,6 +60,61 @@ class Settings(BaseSettings):
         description="AIMBAT database url (default value is derived from `project`).",
     )
 
+    event_duplicate_raise_tolerance: PydanticPositiveTimedelta = Field(
+        default=Timedelta(seconds=2),
+        description=(
+            "Upper bound of the 'ambiguous gap' band: if a new event's origin "
+            "time is further than `event_duplicate_tolerance` but closer than "
+            "this value to an existing event's time, adding it raises an "
+            "error unconditionally (even during `--dry-run`), since a gap this "
+            "size is too large to be ordinary timestamp precision noise but "
+            "too small to confidently be two unrelated events — it usually "
+            "signals a timing problem in the source data that needs "
+            "investigating before import. Ignored entirely when "
+            "`event_duplicate_strict` is True. This check compares origin "
+            "times only, not location — two genuinely distinct, "
+            "geographically unrelated events whose times happen to land "
+            "within this tolerance of each other would still be flagged."
+        ),
+    )
+
+    event_duplicate_strict: bool = Field(
+        default=False,
+        description=(
+            "If True, skip near-duplicate event detection entirely — both "
+            "`event_duplicate_tolerance` and `event_duplicate_raise_tolerance` "
+            "are ignored, and events are only ever merged on an exact origin "
+            "time match. Origin times are stored with microsecond precision, "
+            "so this exact match is itself only accurate to the microsecond: "
+            "two times less than a microsecond apart are always treated as "
+            "the same event, while any gap of a microsecond or more — however "
+            "small — creates a fully independent event with no warning at "
+            "all. Use only when the source data are trusted to already be "
+            "free of timing problems at that precision (e.g. a catalogue "
+            "known to contain legitimately close, but genuinely distinct, "
+            "events such as an aftershock swarm)."
+        ),
+    )
+
+    event_duplicate_tolerance: PydanticPositiveTimedelta = Field(
+        default=Timedelta(seconds=0.1),
+        description=(
+            "Maximum time difference for a new event's origin time to be "
+            "treated as a possible duplicate of an existing one when no exact "
+            "match is found. Real-world origin times are rarely reported to "
+            "better than sub-second precision, and a gap in that range "
+            "usually reflects precision loss upstream (e.g. SAC's 32-bit "
+            "float `o` header) rather than two genuinely distinct events. "
+            "This is meant to catch that precision noise only. Outside "
+            "`--dry-run`, a detected near-duplicate within this tolerance "
+            "raises an error; during `--dry-run` it is reported as a warning "
+            "instead. A larger gap, up to `event_duplicate_raise_tolerance`, "
+            "is handled separately (see that field) rather than being "
+            "treated as ordinary noise. Ignored entirely when "
+            "`event_duplicate_strict` is True."
+        ),
+    )
+
     log_level: Literal[
         "TRACE", "DEBUG", "INFO", "SUCCESS", "WARNING", "ERROR", "CRITICAL"
     ] = Field(
@@ -154,6 +209,16 @@ class Settings(BaseSettings):
         """Derive `db_url` from `project` when not set explicitly."""
         if self.db_url == "":
             self.db_url = f"sqlite+pysqlite:///{self.project}"
+        return self
+
+    @model_validator(mode="after")
+    def validate_event_duplicate_tolerances(self) -> Self:
+        """Ensure the ambiguous-gap band is non-empty."""
+        if self.event_duplicate_raise_tolerance <= self.event_duplicate_tolerance:
+            raise ValueError(
+                "event_duplicate_raise_tolerance must be greater than "
+                "event_duplicate_tolerance."
+            )
         return self
 
 

--- a/src/aimbat/core/_data.py
+++ b/src/aimbat/core/_data.py
@@ -5,10 +5,12 @@ from collections.abc import Callable, Sequence
 from typing import Any
 from uuid import UUID
 
+from pandas import Timedelta
 from pydantic import TypeAdapter
 from sqlalchemy.exc import NoResultFound
 from sqlmodel import Session, select
 
+from aimbat import settings
 from aimbat.io import (
     DataType,
     create_event,
@@ -27,6 +29,7 @@ from aimbat.models._models import (
     _AimbatDataSourceCreate,
 )
 from aimbat.utils import get_title_map
+from aimbat.utils.formatters import fmt_timedelta
 
 __all__ = [
     "add_data_to_project",
@@ -36,7 +39,7 @@ __all__ = [
 
 
 def _create_station(
-    session: Session, datasource: os.PathLike | str, datatype: DataType
+    session: Session, datasource: os.PathLike[str] | str, datatype: DataType
 ) -> AimbatStation:
     """Create a new AimbatStation if it doesn't exist yet, or use existing one."""
 
@@ -64,20 +67,134 @@ def _create_station(
     return aimbat_station
 
 
+def _format_gap_prefix(
+    datasource: os.PathLike[str] | str,
+    new_event: AimbatEvent,
+    existing_event: AimbatEvent,
+    gap: Timedelta,
+) -> str:
+    """Build the shared origin-time/gap/existing-event sentence fragment."""
+    return (
+        f"{datasource} has origin time {new_event.time}, "
+        f"{fmt_timedelta(gap)} from existing event {existing_event.id} "
+        f"({existing_event.time})"
+    )
+
+
+def _format_duplicate_event_message(
+    datasource: os.PathLike[str] | str,
+    new_event: AimbatEvent,
+    existing_event: AimbatEvent,
+    gap: Timedelta,
+    tolerance: Timedelta,
+) -> str:
+    """Build the noise-band near-duplicate-event message."""
+    prefix = _format_gap_prefix(datasource, new_event, existing_event, gap)
+    return (
+        f"Possible duplicate event: {prefix} — within the configured "
+        f"duplicate-detection tolerance ({fmt_timedelta(tolerance)}) but "
+        f"not an exact match. If these are the same event, re-run with "
+        f"'--use-event {existing_event.id}', or import an authoritative "
+        f"event record first using the 'json_event' data type."
+    )
+
+
+def _format_ambiguous_gap_message(
+    datasource: os.PathLike[str] | str,
+    new_event: AimbatEvent,
+    existing_event: AimbatEvent,
+    gap: Timedelta,
+    tolerance: Timedelta,
+    raise_tolerance: Timedelta,
+) -> str:
+    """Build the ambiguous-gap-band event-time-conflict message."""
+    prefix = _format_gap_prefix(datasource, new_event, existing_event, gap)
+    return (
+        f"Event time conflict: {prefix} — too large a gap to be explained "
+        f"by ordinary timestamp precision noise (tolerance "
+        f"{fmt_timedelta(tolerance)}) but too small to confidently treat as "
+        f"an unrelated event (raise threshold {fmt_timedelta(raise_tolerance)}"
+        f"). This usually indicates a timing problem in the source data; "
+        f"check it before importing. If these are known to be genuinely "
+        f"distinct events, set 'event_duplicate_strict' to skip this check."
+    )
+
+
 def _create_event(
-    session: Session, datasource: os.PathLike | str, datatype: DataType
-) -> AimbatEvent:
-    """Create a new AimbatEvent if it doesn't exist yet, or use existing one."""
+    session: Session,
+    datasource: os.PathLike[str] | str,
+    datatype: DataType,
+    dry_run: bool,
+    known_event_ids: set[UUID],
+) -> tuple[AimbatEvent, str | None]:
+    """Create a new AimbatEvent if it doesn't exist yet, or use existing one.
+
+    If no exact time match is found, checks whether the new event's origin
+    time is a near-duplicate of a known event's time, per
+    `settings.event_duplicate_tolerance` / `event_duplicate_raise_tolerance`
+    / `event_duplicate_strict` — see the `data add` module docstring for the
+    three-tier model. `known_event_ids` is updated in place with the ID of
+    any newly created event, so later data sources in the same batch are
+    checked against events created earlier in that batch too.
+
+    Raises:
+        ValueError: If a real add (`dry_run=False`) finds a near-duplicate
+            within `event_duplicate_tolerance`, or if any near-duplicate
+            (regardless of `dry_run`) falls in the wider "ambiguous gap"
+            band up to `event_duplicate_raise_tolerance`.
+    """
 
     new_aimbat_event = create_event(datasource, datatype)
 
     statement = select(AimbatEvent).where(AimbatEvent.time == new_aimbat_event.time)
     aimbat_event = session.exec(statement).one_or_none()
+    duplicate_warning: str | None = None
 
     if aimbat_event is None:
+        if not settings.event_duplicate_strict:
+            tolerance = settings.event_duplicate_tolerance
+            raise_tolerance = settings.event_duplicate_raise_tolerance
+            near_statement = select(AimbatEvent).where(
+                AimbatEvent.time.between(  # type: ignore[attr-defined]
+                    new_aimbat_event.time - raise_tolerance,
+                    new_aimbat_event.time + raise_tolerance,
+                ),
+            )
+            near_duplicates = [
+                e for e in session.exec(near_statement).all() if e.id in known_event_ids
+            ]
+            if near_duplicates:
+                closest = min(
+                    near_duplicates, key=lambda e: abs(e.time - new_aimbat_event.time)
+                )
+                gap = abs(closest.time - new_aimbat_event.time)
+                # Strictly less than raise_tolerance: at or beyond it, the
+                # gap is treated as fully independent (see the setting's
+                # "closer than this value" description in _config.py).
+                if gap < raise_tolerance:
+                    if gap <= tolerance:
+                        message = _format_duplicate_event_message(
+                            datasource, new_aimbat_event, closest, gap, tolerance
+                        )
+                        if dry_run:
+                            duplicate_warning = message
+                        else:
+                            raise ValueError(message)
+                    else:
+                        raise ValueError(
+                            _format_ambiguous_gap_message(
+                                datasource,
+                                new_aimbat_event,
+                                closest,
+                                gap,
+                                tolerance,
+                                raise_tolerance,
+                            )
+                        )
         aimbat_event = new_aimbat_event
         logger.debug(f"Adding event {aimbat_event.time} to project.")
         session.add(aimbat_event)
+        known_event_ids.add(aimbat_event.id)
     else:
         logger.debug(
             f"Using existing event {aimbat_event.time} instead of adding new one."
@@ -91,11 +208,12 @@ def _create_event(
                 f"Event at {aimbat_event.time} matched by time but has different "
                 f"location metadata in {datasource}. The existing record will be used."
             )
-    return aimbat_event
+
+    return aimbat_event, duplicate_warning
 
 
 def _create_seismogram(
-    session: Session, datasource: os.PathLike | str, datatype: DataType
+    session: Session, datasource: os.PathLike[str] | str, datatype: DataType
 ) -> AimbatSeismogram:
     """Create a new AimbatSeismogram if it doesn't exist yet, or use existing one."""
 
@@ -121,11 +239,13 @@ def _create_seismogram(
 
 def _process_datasource(
     session: Session,
-    datasource: os.PathLike | str,
+    datasource: os.PathLike[str] | str,
     datatype: DataType,
     station_id: UUID | None,
     event_id: UUID | None,
-) -> AimbatDataSource | None:
+    dry_run: bool,
+    known_event_ids: set[UUID],
+) -> tuple[AimbatDataSource | None, str | None]:
     """Process a single data source, creating whichever entities the data type supports.
 
     Returns an `AimbatDataSource` when seismogram data are created, or `None`
@@ -140,16 +260,31 @@ def _process_datasource(
             extracting one from `datasource`.
         event_id: UUID of an existing event to link to instead of extracting
             one from `datasource`.
+        dry_run: If True, a near-duplicate event within
+            `settings.event_duplicate_tolerance` is collected as a warning
+            instead of raising.
+        known_event_ids: IDs of events eligible for near-duplicate matching;
+            updated in place as new events are created, so later data sources
+            in the same batch are checked against earlier ones too.
 
     Returns:
-        The created or reused `AimbatDataSource`, or `None` if `datatype`
-        does not support seismogram creation.
+        A 2-tuple of the created or reused `AimbatDataSource` (or `None` if
+        `datatype` does not support seismogram creation) and a near-duplicate
+        warning message (or `None` if no near-duplicate was found, or if the
+        one found was outside `settings.event_duplicate_tolerance`).
 
     Raises:
-        ValueError: If `event_id` is given but no matching event exists, or
-            if `datatype` does not support the station or event creation
-            required to link a seismogram.
+        ValueError: If `event_id` is given but no matching event exists, if
+            `datatype` does not support the station or event creation
+            required to link a seismogram, if a real add (`dry_run=False`)
+            finds a near-duplicate event within
+            `settings.event_duplicate_tolerance`, or if a near-duplicate
+            event falls in the wider "ambiguous gap" band up to
+            `settings.event_duplicate_raise_tolerance` — the latter is
+            raised regardless of `dry_run`.
     """
+
+    duplicate_warning: str | None = None
 
     # Resolve station — use the provided UUID, extract from the source, or skip
     if station_id is not None:
@@ -169,13 +304,15 @@ def _process_datasource(
             raise ValueError(f"No event found with ID={event_id}.")
         logger.debug(f"Using event {aimbat_event.time} (ID={event_id}).")
     elif supports_event_creation(datatype):
-        aimbat_event = _create_event(session, datasource, datatype)
+        aimbat_event, duplicate_warning = _create_event(
+            session, datasource, datatype, dry_run, known_event_ids
+        )
     else:
         aimbat_event = None
 
     # No seismogram creation → station/event-only import, nothing more to do
     if not supports_seismogram_creation(datatype):
-        return None
+        return None, duplicate_warning
 
     # Seismogram creation requires both a station and an event to link to
     if aimbat_station is None:
@@ -215,18 +352,18 @@ def _process_datasource(
         )
         aimbat_data_source.seismogram = aimbat_seismogram
     session.add(aimbat_data_source)
-    return aimbat_data_source
+    return aimbat_data_source, duplicate_warning
 
 
 def add_data_to_project(
     session: Session,
-    data_sources: Sequence[os.PathLike | str],
+    data_sources: Sequence[os.PathLike[str] | str],
     data_type: DataType,
     station_id: UUID | None = None,
     event_id: UUID | None = None,
     dry_run: bool = False,
     on_progress: Callable[[int, int], None] | None = None,
-) -> tuple[list[AimbatDataSource], set[UUID], set[UUID], set[UUID]]:
+) -> tuple[list[AimbatDataSource], set[UUID], set[UUID], set[UUID], list[str]]:
     """Add data sources to the AIMBAT database.
 
     What gets created depends on which capabilities `data_type` supports:
@@ -239,6 +376,14 @@ def add_data_to_project(
 
     Use `station_id` or `event_id` to skip extracting station or event metadata
     from the data source and link to a pre-existing record instead.
+
+    A new event whose origin time nearly, but not exactly, matches a
+    pre-existing event's time is flagged as a possible near-duplicate (see
+    `settings.event_duplicate_tolerance`, `event_duplicate_raise_tolerance`,
+    and `event_duplicate_strict`). Within the tighter tolerance, a real add
+    raises `ValueError` while a dry run collects a warning instead; within
+    the wider "ambiguous gap" band, a `ValueError` is raised unconditionally,
+    even during a dry run.
 
     Args:
         session: The SQLModel database session.
@@ -254,13 +399,19 @@ def add_data_to_project(
             display progress.
 
     Returns:
-        A 4-tuple of `(added_datasources, existing_station_ids,
-        existing_event_ids, existing_seismogram_ids)`. `added_datasources` is
-        every `AimbatDataSource` touched by this call, new or reused.
-        `existing_*_ids` are the sets of station/event/seismogram IDs that
-        already existed in the database *before* this call, so callers can
-        tell which entries in `added_datasources` are newly created versus
-        reused by comparing IDs against these sets.
+        A 5-tuple of `(added_datasources, existing_station_ids,
+        existing_event_ids, existing_seismogram_ids, duplicate_warnings)`.
+        `added_datasources` is every `AimbatDataSource` touched by this call,
+        new or reused. `existing_*_ids` are the sets of station/event/
+        seismogram IDs that already existed in the database *before* this
+        call, so callers can tell which entries in `added_datasources` are
+        newly created versus reused by comparing IDs against these sets.
+        `duplicate_warnings` lists near-duplicate-event messages collected
+        during a dry run (always empty on a real-add call, since a real-add
+        near-duplicate raises instead of being collected).
+
+    Raises:
+        ValueError: If a near-duplicate event is found — see above.
     """
 
     logger.info(f"Adding {len(data_sources)} {data_type} data sources to project.")
@@ -276,16 +427,31 @@ def add_data_to_project(
     existing_event_ids = set(session.exec(select(AimbatEvent.id)).all())
     existing_seismogram_ids = set(session.exec(select(AimbatSeismogram.id)).all())
 
+    # Mutated in place as new events are created, so near-duplicate
+    # detection also covers events created earlier in this same batch —
+    # unlike existing_event_ids, which stays a frozen pre-batch snapshot
+    # for the return value's new-vs-reused semantics.
+    known_event_ids = set(existing_event_ids)
+
     try:
         added_datasources: list[AimbatDataSource] = []
+        duplicate_warnings: list[str] = []
         total = len(data_sources)
         with session.begin_nested() as nested:
             for done, datasource in enumerate(data_sources, start=1):
-                result = _process_datasource(
-                    session, datasource, data_type, station_id, event_id
+                result, duplicate_warning = _process_datasource(
+                    session,
+                    datasource,
+                    data_type,
+                    station_id,
+                    event_id,
+                    dry_run,
+                    known_event_ids,
                 )
                 if result is not None:
                     added_datasources.append(result)
+                if duplicate_warning is not None:
+                    duplicate_warnings.append(duplicate_warning)
                 if on_progress is not None:
                     on_progress(done, total)
 
@@ -300,6 +466,7 @@ def add_data_to_project(
                     existing_station_ids,
                     existing_event_ids,
                     existing_seismogram_ids,
+                    duplicate_warnings,
                 )
 
         session.commit()
@@ -309,6 +476,7 @@ def add_data_to_project(
             existing_station_ids,
             existing_event_ids,
             existing_seismogram_ids,
+            duplicate_warnings,
         )
 
     except Exception as e:

--- a/src/aimbat/io/_base.py
+++ b/src/aimbat/io/_base.py
@@ -56,20 +56,22 @@ __all__ = [
 _cache: dict[tuple[str, DataType], npt.NDArray[np.float64]] = {}
 
 # Per-capability registries — populated by data source modules (e.g. _sac)
-_station_creators: dict[DataType, Callable[[str | PathLike], AimbatStation]] = {}
-_event_creators: dict[DataType, Callable[[str | PathLike], AimbatEvent]] = {}
-_seismogram_creators: dict[DataType, Callable[[str | PathLike], AimbatSeismogram]] = {}
+_station_creators: dict[DataType, Callable[[str | PathLike[str]], AimbatStation]] = {}
+_event_creators: dict[DataType, Callable[[str | PathLike[str]], AimbatEvent]] = {}
+_seismogram_creators: dict[
+    DataType, Callable[[str | PathLike[str]], AimbatSeismogram]
+] = {}
 _seismogram_data_readers: dict[
-    DataType, Callable[[str | PathLike], npt.NDArray[np.float64]]
+    DataType, Callable[[str | PathLike[str]], npt.NDArray[np.float64]]
 ] = {}
 _seismogram_data_writers: dict[
-    DataType, Callable[[str | PathLike, npt.NDArray[np.float64]], None]
+    DataType, Callable[[str | PathLike[str], npt.NDArray[np.float64]], None]
 ] = {}
 
 
 def register_station_creator(
     datatype: DataType,
-    fn: Callable[[str | PathLike], AimbatStation],
+    fn: Callable[[str | PathLike[str]], AimbatStation],
 ) -> None:
     """Register a function that creates an `AimbatStation` from a data source.
 
@@ -84,7 +86,7 @@ def register_station_creator(
 
 def register_event_creator(
     datatype: DataType,
-    fn: Callable[[str | PathLike], AimbatEvent],
+    fn: Callable[[str | PathLike[str]], AimbatEvent],
 ) -> None:
     """Register a function that creates an `AimbatEvent` from a data source.
 
@@ -99,7 +101,7 @@ def register_event_creator(
 
 def register_seismogram_creator(
     datatype: DataType,
-    fn: Callable[[str | PathLike], AimbatSeismogram],
+    fn: Callable[[str | PathLike[str]], AimbatSeismogram],
 ) -> None:
     """Register a function that creates an `AimbatSeismogram` from a data source.
 
@@ -114,7 +116,7 @@ def register_seismogram_creator(
 
 def register_seismogram_data_reader(
     datatype: DataType,
-    fn: Callable[[str | PathLike], npt.NDArray[np.float64]],
+    fn: Callable[[str | PathLike[str]], npt.NDArray[np.float64]],
 ) -> None:
     """Register a function that reads seismogram waveform data from a data source.
 
@@ -129,7 +131,7 @@ def register_seismogram_data_reader(
 
 def register_seismogram_data_writer(
     datatype: DataType,
-    fn: Callable[[str | PathLike, npt.NDArray[np.float64]], None],
+    fn: Callable[[str | PathLike[str], npt.NDArray[np.float64]], None],
 ) -> None:
     """Register a function that writes seismogram waveform data to a data source.
 
@@ -145,8 +147,8 @@ def register_seismogram_data_writer(
 def station_creator(
     datatype: DataType,
 ) -> Callable[
-    [Callable[[str | PathLike], AimbatStation]],
-    Callable[[str | PathLike], AimbatStation],
+    [Callable[[str | PathLike[str]], AimbatStation]],
+    Callable[[str | PathLike[str]], AimbatStation],
 ]:
     """Decorator that registers a function as a station creator for `datatype`.
 
@@ -156,14 +158,14 @@ def station_creator(
     Example:
         ```python
         @station_creator(DataType.SAC)
-        def create_station_from_sacfile(sacfile: str | PathLike) -> AimbatStation:
+        def create_station_from_sacfile(sacfile: str | PathLike[str]) -> AimbatStation:
             ...
         ```
     """
 
     def decorator(
-        fn: Callable[[str | PathLike], AimbatStation],
-    ) -> Callable[[str | PathLike], AimbatStation]:
+        fn: Callable[[str | PathLike[str]], AimbatStation],
+    ) -> Callable[[str | PathLike[str]], AimbatStation]:
         register_station_creator(datatype, fn)
         return fn
 
@@ -173,7 +175,8 @@ def station_creator(
 def event_creator(
     datatype: DataType,
 ) -> Callable[
-    [Callable[[str | PathLike], AimbatEvent]], Callable[[str | PathLike], AimbatEvent]
+    [Callable[[str | PathLike[str]], AimbatEvent]],
+    Callable[[str | PathLike[str]], AimbatEvent],
 ]:
     """Decorator that registers a function as an event creator for `datatype`.
 
@@ -183,14 +186,14 @@ def event_creator(
     Example:
         ```python
         @event_creator(DataType.SAC)
-        def create_event_from_sacfile(sacfile: str | PathLike) -> AimbatEvent:
+        def create_event_from_sacfile(sacfile: str | PathLike[str]) -> AimbatEvent:
             ...
         ```
     """
 
     def decorator(
-        fn: Callable[[str | PathLike], AimbatEvent],
-    ) -> Callable[[str | PathLike], AimbatEvent]:
+        fn: Callable[[str | PathLike[str]], AimbatEvent],
+    ) -> Callable[[str | PathLike[str]], AimbatEvent]:
         register_event_creator(datatype, fn)
         return fn
 
@@ -200,8 +203,8 @@ def event_creator(
 def seismogram_creator(
     datatype: DataType,
 ) -> Callable[
-    [Callable[[str | PathLike], AimbatSeismogram]],
-    Callable[[str | PathLike], AimbatSeismogram],
+    [Callable[[str | PathLike[str]], AimbatSeismogram]],
+    Callable[[str | PathLike[str]], AimbatSeismogram],
 ]:
     """Decorator that registers a function as a seismogram creator for `datatype`.
 
@@ -211,14 +214,14 @@ def seismogram_creator(
     Example:
         ```python
         @seismogram_creator(DataType.SAC)
-        def create_seismogram_from_sacfile(sacfile: str | PathLike) -> AimbatSeismogram:
+        def create_seismogram_from_sacfile(sacfile: str | PathLike[str]) -> AimbatSeismogram:
             ...
         ```
     """
 
     def decorator(
-        fn: Callable[[str | PathLike], AimbatSeismogram],
-    ) -> Callable[[str | PathLike], AimbatSeismogram]:
+        fn: Callable[[str | PathLike[str]], AimbatSeismogram],
+    ) -> Callable[[str | PathLike[str]], AimbatSeismogram]:
         register_seismogram_creator(datatype, fn)
         return fn
 
@@ -228,8 +231,8 @@ def seismogram_creator(
 def seismogram_data_reader(
     datatype: DataType,
 ) -> Callable[
-    [Callable[[str | PathLike], npt.NDArray[np.float64]]],
-    Callable[[str | PathLike], npt.NDArray[np.float64]],
+    [Callable[[str | PathLike[str]], npt.NDArray[np.float64]]],
+    Callable[[str | PathLike[str]], npt.NDArray[np.float64]],
 ]:
     """Decorator that registers a function as a seismogram data reader for `datatype`.
 
@@ -239,14 +242,14 @@ def seismogram_data_reader(
     Example:
         ```python
         @seismogram_data_reader(DataType.SAC)
-        def read_seismogram_data_from_sacfile(sacfile: str | PathLike) -> npt.NDArray[np.float64]:
+        def read_seismogram_data_from_sacfile(sacfile: str | PathLike[str]) -> npt.NDArray[np.float64]:
             ...
         ```
     """
 
     def decorator(
-        fn: Callable[[str | PathLike], npt.NDArray[np.float64]],
-    ) -> Callable[[str | PathLike], npt.NDArray[np.float64]]:
+        fn: Callable[[str | PathLike[str]], npt.NDArray[np.float64]],
+    ) -> Callable[[str | PathLike[str]], npt.NDArray[np.float64]]:
         register_seismogram_data_reader(datatype, fn)
         return fn
 
@@ -256,8 +259,8 @@ def seismogram_data_reader(
 def seismogram_data_writer(
     datatype: DataType,
 ) -> Callable[
-    [Callable[[str | PathLike, npt.NDArray[np.float64]], None]],
-    Callable[[str | PathLike, npt.NDArray[np.float64]], None],
+    [Callable[[str | PathLike[str], npt.NDArray[np.float64]], None]],
+    Callable[[str | PathLike[str], npt.NDArray[np.float64]], None],
 ]:
     """Decorator that registers a function as a seismogram data writer for `datatype`.
 
@@ -268,15 +271,15 @@ def seismogram_data_writer(
         ```python
         @seismogram_data_writer(DataType.SAC)
         def write_seismogram_data_to_sacfile(
-            sacfile: str | PathLike, data: npt.NDArray[np.float64]
+            sacfile: str | PathLike[str], data: npt.NDArray[np.float64]
         ) -> None:
             ...
         ```
     """
 
     def decorator(
-        fn: Callable[[str | PathLike, npt.NDArray[np.float64]], None],
-    ) -> Callable[[str | PathLike, npt.NDArray[np.float64]], None]:
+        fn: Callable[[str | PathLike[str], npt.NDArray[np.float64]], None],
+    ) -> Callable[[str | PathLike[str], npt.NDArray[np.float64]], None]:
         register_seismogram_data_writer(datatype, fn)
         return fn
 
@@ -308,7 +311,9 @@ def supports_seismogram_data_writing(datatype: DataType) -> bool:
     return datatype in _seismogram_data_writers
 
 
-def create_station(datasource: str | PathLike, datatype: DataType) -> AimbatStation:
+def create_station(
+    datasource: str | PathLike[str], datatype: DataType
+) -> AimbatStation:
     """Create an `AimbatStation` from a data source.
 
     Args:
@@ -328,7 +333,7 @@ def create_station(datasource: str | PathLike, datatype: DataType) -> AimbatStat
     return creator(datasource)
 
 
-def create_event(datasource: str | PathLike, datatype: DataType) -> AimbatEvent:
+def create_event(datasource: str | PathLike[str], datatype: DataType) -> AimbatEvent:
     """Create an `AimbatEvent` from a data source.
 
     Args:
@@ -349,7 +354,7 @@ def create_event(datasource: str | PathLike, datatype: DataType) -> AimbatEvent:
 
 
 def create_seismogram(
-    datasource: str | PathLike, datatype: DataType
+    datasource: str | PathLike[str], datatype: DataType
 ) -> AimbatSeismogram:
     """Create an `AimbatSeismogram` from a data source.
 
@@ -371,7 +376,7 @@ def create_seismogram(
 
 
 def read_seismogram_data(
-    datasource: str | PathLike, datatype: DataType
+    datasource: str | PathLike[str], datatype: DataType
 ) -> npt.NDArray[np.float64]:
     """Read seismogram waveform data from a data source.
 
@@ -407,7 +412,7 @@ def read_seismogram_data(
 
 
 def write_seismogram_data(
-    datasource: str | PathLike,
+    datasource: str | PathLike[str],
     datatype: DataType,
     data: npt.NDArray[np.float64],
 ) -> None:

--- a/src/aimbat/io/json.py
+++ b/src/aimbat/io/json.py
@@ -51,7 +51,7 @@ __all__ = [
 
 
 @station_creator(DataType.JSON_STATION)
-def create_station_from_json(path: str | PathLike) -> AimbatStation:
+def create_station_from_json(path: str | PathLike[str]) -> AimbatStation:
     """Create an `AimbatStation` from a JSON file.
 
     Args:
@@ -70,7 +70,7 @@ def create_station_from_json(path: str | PathLike) -> AimbatStation:
 
 
 @event_creator(DataType.JSON_EVENT)
-def create_event_from_json(path: str | PathLike) -> AimbatEvent:
+def create_event_from_json(path: str | PathLike[str]) -> AimbatEvent:
     """Create an `AimbatEvent` from a JSON file.
 
     Args:

--- a/src/aimbat/io/sac.py
+++ b/src/aimbat/io/sac.py
@@ -45,7 +45,7 @@ __all__ = [
 
 @seismogram_data_reader(DataType.SAC)
 def read_seismogram_data_from_sacfile(
-    sacfile: str | PathLike,
+    sacfile: str | PathLike[str],
 ) -> npt.NDArray[np.float64]:
     """Read seismogram waveform data from a SAC file.
 
@@ -63,7 +63,7 @@ def read_seismogram_data_from_sacfile(
 
 @seismogram_data_writer(DataType.SAC)
 def write_seismogram_data_to_sacfile(
-    sacfile: str | PathLike, data: npt.NDArray[np.float64]
+    sacfile: str | PathLike[str], data: npt.NDArray[np.float64]
 ) -> None:
     """Write seismogram waveform data to a SAC file.
 
@@ -80,7 +80,7 @@ def write_seismogram_data_to_sacfile(
 
 
 @station_creator(DataType.SAC)
-def create_station_from_sacfile(sacfile: str | PathLike) -> AimbatStation:
+def create_station_from_sacfile(sacfile: str | PathLike[str]) -> AimbatStation:
     """Create an `AimbatStation` instance from a SAC file.
 
     Args:
@@ -100,7 +100,7 @@ def create_station_from_sacfile(sacfile: str | PathLike) -> AimbatStation:
 
 
 @event_creator(DataType.SAC)
-def create_event_from_sacfile(sacfile: str | PathLike) -> AimbatEvent:
+def create_event_from_sacfile(sacfile: str | PathLike[str]) -> AimbatEvent:
     """Create an `AimbatEvent` instance from a SAC file.
 
     Args:
@@ -122,7 +122,7 @@ def create_event_from_sacfile(sacfile: str | PathLike) -> AimbatEvent:
 
 
 def create_seismogram_from_sacfile_and_pick_header(
-    sacfile: str | PathLike, sac_pick_header: str
+    sacfile: str | PathLike[str], sac_pick_header: str
 ) -> AimbatSeismogram:
     """Create an `AimbatSeismogram` instance from a SAC file.
 
@@ -148,7 +148,7 @@ def create_seismogram_from_sacfile_and_pick_header(
 
 
 @seismogram_creator(DataType.SAC)
-def create_seismogram_from_sacfile(sacfile: str | PathLike) -> AimbatSeismogram:
+def create_seismogram_from_sacfile(sacfile: str | PathLike[str]) -> AimbatSeismogram:
     """Create an `AimbatSeismogram` instance from a SAC file, using the configured pick header.
 
     Args:

--- a/src/aimbat/models/_models.py
+++ b/src/aimbat/models/_models.py
@@ -54,7 +54,7 @@ __all__ = [
 class _AimbatDataSourceCreate(SQLModel):
     """Input model for creating a new data source entry."""
 
-    sourcename: os.PathLike | str = Field(
+    sourcename: os.PathLike[str] | str = Field(
         unique=True,
     )
     datatype: DataType = Field(
@@ -372,7 +372,6 @@ class AimbatSnapshot(SQLModel, table=True):
     time: PydanticTimestamp = Field(
         default_factory=lambda: Timestamp.now(tz=timezone.utc),
         unique=True,
-        allow_mutation=False,
         sa_type=SAPandasTimestamp,
         title="Snapshot time",
         description="Timestamp when the snapshot was created.",
@@ -577,22 +576,18 @@ class AimbatStation(SQLModel, table=True):
         schema_extra={"rich": RichColSpec(style="yellow", highlight=False)},
     )
     name: str = Field(
-        allow_mutation=False,
         title="Name",
         description="Station name (SEED station code).",
     )
     network: str = Field(
-        allow_mutation=False,
         title="Network",
         description="Network code.",
     )
     location: str = Field(
-        allow_mutation=False,
         title="Location",
         description="Location code.",
     )
     channel: str = Field(
-        allow_mutation=False,
         title="Channel",
         description="Channel code (e.g. BHZ).",
     )
@@ -634,7 +629,6 @@ class AimbatEvent(SQLModel, table=True):
     time: PydanticTimestamp = Field(
         unique=True,
         sa_type=SAPandasTimestamp,
-        allow_mutation=False,
         title="Time",
         description="Event origin time (UTC).",
     )

--- a/tests/integration/core/test_data.py
+++ b/tests/integration/core/test_data.py
@@ -1,11 +1,12 @@
 """Integration tests for adding data to the project (aimbat.core._data)."""
 
 import json
+import shutil
 import uuid
 from pathlib import Path
 
 import pytest
-from pandas import Timestamp
+from pandas import Timedelta, Timestamp
 from pydantic import ValidationError
 from sqlalchemy import Engine
 from sqlalchemy.exc import NoResultFound
@@ -13,6 +14,7 @@ from sqlmodel import Session, select
 
 from pysmo.classes import SAC
 
+import aimbat
 from aimbat.core import (
     add_data_to_project,
     dump_data_table,
@@ -22,6 +24,7 @@ from aimbat.io import DataType
 from aimbat.models import (
     AimbatDataSource,
     AimbatEvent,
+    AimbatEventParameters,
     AimbatSeismogram,
     AimbatStation,
 )
@@ -216,6 +219,7 @@ class TestAddDataToProject:
             existing_station_ids,
             existing_event_ids,
             existing_seismogram_ids,
+            duplicate_warnings,
         ) = result
         n = len(multi_event_data)
         assert len(added_datasources) == n
@@ -229,6 +233,7 @@ class TestAddDataToProject:
         assert all(
             ds.seismogram_id not in existing_seismogram_ids for ds in added_datasources
         )
+        assert duplicate_warnings == []
 
     def test_dry_run_all_skipped(
         self,
@@ -260,6 +265,7 @@ class TestAddDataToProject:
             existing_station_ids,
             existing_event_ids,
             existing_seismogram_ids,
+            duplicate_warnings,
         ) = result
         n = len(multi_event_data)
         assert len(added_datasources) == n
@@ -272,6 +278,7 @@ class TestAddDataToProject:
         assert all(
             ds.seismogram_id in existing_seismogram_ids for ds in added_datasources
         )
+        assert duplicate_warnings == []
 
     def test_real_run_all_new(
         self,
@@ -289,6 +296,7 @@ class TestAddDataToProject:
             existing_station_ids,
             existing_event_ids,
             existing_seismogram_ids,
+            duplicate_warnings,
         ) = add_data_to_project(
             patched_session,
             multi_event_data,
@@ -300,6 +308,7 @@ class TestAddDataToProject:
         assert all(
             ds.seismogram_id not in existing_seismogram_ids for ds in added_datasources
         )
+        assert duplicate_warnings == []
 
         datasource = patched_session.exec(select(AimbatDataSource.sourcename)).all()
         assert len(datasource) == n, "Expected data to actually be committed."
@@ -326,6 +335,7 @@ class TestAddDataToProject:
             _existing_station_ids,
             _existing_event_ids,
             existing_seismogram_ids,
+            duplicate_warnings,
         ) = add_data_to_project(
             patched_session,
             multi_event_data,
@@ -336,6 +346,300 @@ class TestAddDataToProject:
         assert all(
             ds.seismogram_id in existing_seismogram_ids for ds in added_datasources
         )
+        assert duplicate_warnings == []
+
+
+class TestNearDuplicateEventDetection:
+    """Tests for near-duplicate event detection in add_data_to_project."""
+
+    @staticmethod
+    def _shifted_copy(
+        source: Path, tmp_path: Path, shift_seconds: float, name: str
+    ) -> Path:
+        """Copy `source` to `tmp_path/name`, shifting its event time.
+
+        Args:
+            source: Path to the SAC file to copy.
+            tmp_path: Directory to copy into.
+            shift_seconds: Seconds to shift the copy's event time by.
+            name: Filename for the copy.
+
+        Returns:
+            Path to the shifted copy.
+        """
+        new_path = tmp_path / name
+        shutil.copy(source, new_path)
+        sac = SAC.from_file(new_path)
+        sac.event.time = sac.event.time + Timedelta(seconds=shift_seconds)
+        sac.write(new_path)
+        return new_path
+
+    @staticmethod
+    def _seed_event(session: Session, time: Timestamp) -> AimbatEvent:
+        """Insert an event directly via the ORM, bypassing add_data_to_project.
+
+        Args:
+            session: Database session.
+            time: Event origin time.
+
+        Returns:
+            The inserted AimbatEvent.
+        """
+        event = AimbatEvent(time=time, latitude=35.0, longitude=-120.0, depth=10.0)
+        session.add(event)
+        session.flush()
+        session.add(AimbatEventParameters(event=event))
+        session.flush()
+        return event
+
+    # -- Noise band (within event_duplicate_tolerance) --------------------
+
+    def test_near_duplicate_event_raises_on_real_add(
+        self, sac_file_good: Path, patched_session: Session, tmp_path: Path
+    ) -> None:
+        """A real add raises when within event_duplicate_tolerance of an existing event.
+
+        Args:
+            sac_file_good: Path to a valid SAC file.
+            patched_session: Database session.
+            tmp_path: Temporary directory for the shifted copy.
+        """
+        add_data_to_project(patched_session, [sac_file_good], data_type=DataType.SAC)
+        near_dup = self._shifted_copy(sac_file_good, tmp_path, 0.02, "near_dup.sac")
+
+        with pytest.raises(ValueError):
+            add_data_to_project(patched_session, [near_dup], data_type=DataType.SAC)
+
+        assert len(patched_session.exec(select(AimbatEvent)).all()) == 1
+
+    def test_near_duplicate_event_warns_on_dry_run(
+        self, sac_file_good: Path, patched_session: Session, tmp_path: Path
+    ) -> None:
+        """A dry run collects a warning instead of raising within the noise band.
+
+        Args:
+            sac_file_good: Path to a valid SAC file.
+            patched_session: Database session.
+            tmp_path: Temporary directory for the shifted copy.
+        """
+        add_data_to_project(patched_session, [sac_file_good], data_type=DataType.SAC)
+        near_dup = self._shifted_copy(sac_file_good, tmp_path, 0.02, "near_dup.sac")
+
+        (
+            added_datasources,
+            _existing_station_ids,
+            existing_event_ids,
+            _existing_seismogram_ids,
+            duplicate_warnings,
+        ) = add_data_to_project(
+            patched_session, [near_dup], data_type=DataType.SAC, dry_run=True
+        )
+
+        assert len(duplicate_warnings) == 1
+        assert str(near_dup) in duplicate_warnings[0]
+
+        # First-wins preview: the near-duplicate is still listed as a newly
+        # added event in the same call that produces the warning.
+        assert len(added_datasources) == 1
+        assert added_datasources[0].seismogram.event_id not in existing_event_ids
+
+    # -- Ambiguous-gap band (between the two tolerances) -------------------
+
+    def test_ambiguous_gap_raises_on_real_add(
+        self, sac_file_good: Path, patched_session: Session, tmp_path: Path
+    ) -> None:
+        """A real add raises with a data-problem message in the ambiguous-gap band.
+
+        Args:
+            sac_file_good: Path to a valid SAC file.
+            patched_session: Database session.
+            tmp_path: Temporary directory for the shifted copy.
+        """
+        add_data_to_project(patched_session, [sac_file_good], data_type=DataType.SAC)
+        ambiguous = self._shifted_copy(sac_file_good, tmp_path, 1.0, "ambiguous.sac")
+
+        with pytest.raises(ValueError) as excinfo:
+            add_data_to_project(patched_session, [ambiguous], data_type=DataType.SAC)
+
+        assert "--use-event" not in str(excinfo.value)
+        assert "timing problem" in str(excinfo.value)
+        assert len(patched_session.exec(select(AimbatEvent)).all()) == 1
+
+    def test_ambiguous_gap_raises_even_on_dry_run(
+        self, sac_file_good: Path, patched_session: Session, tmp_path: Path
+    ) -> None:
+        """A dry run still raises in the ambiguous-gap band, unlike the noise band.
+
+        Args:
+            sac_file_good: Path to a valid SAC file.
+            patched_session: Database session.
+            tmp_path: Temporary directory for the shifted copy.
+        """
+        add_data_to_project(patched_session, [sac_file_good], data_type=DataType.SAC)
+        ambiguous = self._shifted_copy(sac_file_good, tmp_path, 1.0, "ambiguous.sac")
+
+        with pytest.raises(ValueError):
+            add_data_to_project(
+                patched_session, [ambiguous], data_type=DataType.SAC, dry_run=True
+            )
+
+    # -- Independent events and edge cases ---------------------------------
+
+    def test_events_beyond_raise_tolerance_are_independent(
+        self, sac_file_good: Path, patched_session: Session, tmp_path: Path
+    ) -> None:
+        """A real add beyond event_duplicate_raise_tolerance is not flagged.
+
+        Args:
+            sac_file_good: Path to a valid SAC file.
+            patched_session: Database session.
+            tmp_path: Temporary directory for the shifted copy.
+        """
+        add_data_to_project(patched_session, [sac_file_good], data_type=DataType.SAC)
+        independent = self._shifted_copy(
+            sac_file_good, tmp_path, 3.0, "independent.sac"
+        )
+
+        add_data_to_project(patched_session, [independent], data_type=DataType.SAC)
+
+        assert len(patched_session.exec(select(AimbatEvent)).all()) == 2
+
+    def test_same_batch_near_duplicates_are_flagged(
+        self, sac_file_good: Path, patched_session: Session, tmp_path: Path
+    ) -> None:
+        """Near-duplicates within the same batch are compared against each other too.
+
+        Args:
+            sac_file_good: Path to a valid SAC file.
+            patched_session: Database session.
+            tmp_path: Temporary directory for the shifted copy.
+        """
+        near_dup = self._shifted_copy(sac_file_good, tmp_path, 0.02, "near_dup.sac")
+
+        with pytest.raises(ValueError):
+            add_data_to_project(
+                patched_session, [sac_file_good, near_dup], data_type=DataType.SAC
+            )
+
+        # The whole batch shares one nested transaction, so the raise on the
+        # second file rolls back the first file's event too.
+        assert len(patched_session.exec(select(AimbatEvent)).all()) == 0
+
+    def test_gap_exactly_at_raise_tolerance_is_independent(
+        self, event_json: Path, patched_session: Session
+    ) -> None:
+        """A gap exactly equal to event_duplicate_raise_tolerance is not flagged.
+
+        Uses a JSON event rather than a SAC file so both origin times are
+        exact to the microsecond: SAC's 32-bit float header leaves the new
+        event's time with sub-microsecond noise that a DB round trip (which
+        floors to microsecond precision) would not reproduce on the seeded
+        side, masking the exact boundary this test targets.
+
+        Args:
+            event_json: Path to a JSON event file.
+            patched_session: Database session.
+        """
+        new_time = Timestamp(_EVENT_DATA["time"])
+        self._seed_event(patched_session, new_time + Timedelta(seconds=2))
+
+        add_data_to_project(
+            patched_session, [event_json], data_type=DataType.JSON_EVENT
+        )
+
+        assert len(patched_session.exec(select(AimbatEvent)).all()) == 2
+
+    def test_multiple_near_duplicates_picks_closest(
+        self, sac_file_good: Path, patched_session: Session
+    ) -> None:
+        """The closest pre-existing near-duplicate is identified, not the first found.
+
+        Args:
+            sac_file_good: Path to a valid SAC file.
+            patched_session: Database session.
+        """
+        new_time = SAC.from_file(sac_file_good).event.time
+        far = self._seed_event(patched_session, new_time - Timedelta(seconds=0.09))
+        close = self._seed_event(patched_session, new_time + Timedelta(seconds=0.04))
+
+        with pytest.raises(ValueError) as excinfo:
+            add_data_to_project(
+                patched_session, [sac_file_good], data_type=DataType.SAC
+            )
+
+        assert str(close.id) in str(excinfo.value)
+        assert str(far.id) not in str(excinfo.value)
+
+    def test_closest_match_determines_band(
+        self, sac_file_good: Path, patched_session: Session
+    ) -> None:
+        """Band classification is based on the closest match, not the query window.
+
+        Args:
+            sac_file_good: Path to a valid SAC file.
+            patched_session: Database session.
+        """
+        new_time = SAC.from_file(sac_file_good).event.time
+        noise_band_event = self._seed_event(
+            patched_session, new_time + Timedelta(seconds=0.05)
+        )
+        self._seed_event(patched_session, new_time - Timedelta(seconds=1))
+
+        with pytest.raises(ValueError) as excinfo:
+            add_data_to_project(
+                patched_session, [sac_file_good], data_type=DataType.SAC
+            )
+
+        assert "--use-event" in str(excinfo.value)
+        assert str(noise_band_event.id) in str(excinfo.value)
+
+    # -- strict mode ---------------------------------------------------
+
+    def test_strict_skips_noise_band(
+        self,
+        sac_file_good: Path,
+        patched_session: Session,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """event_duplicate_strict=True skips the noise-band check.
+
+        Args:
+            sac_file_good: Path to a valid SAC file.
+            patched_session: Database session.
+            tmp_path: Temporary directory for the shifted copy.
+            monkeypatch: Fixture to mock objects/attributes.
+        """
+        monkeypatch.setattr(aimbat.settings, "event_duplicate_strict", True)
+        add_data_to_project(patched_session, [sac_file_good], data_type=DataType.SAC)
+        near_dup = self._shifted_copy(sac_file_good, tmp_path, 0.02, "near_dup.sac")
+
+        add_data_to_project(patched_session, [near_dup], data_type=DataType.SAC)
+
+        assert len(patched_session.exec(select(AimbatEvent)).all()) == 2
+
+    def test_strict_skips_ambiguous_gap_band(
+        self,
+        sac_file_good: Path,
+        patched_session: Session,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """event_duplicate_strict=True also skips the ambiguous-gap-band check.
+
+        Args:
+            sac_file_good: Path to a valid SAC file.
+            patched_session: Database session.
+            tmp_path: Temporary directory for the shifted copy.
+            monkeypatch: Fixture to mock objects/attributes.
+        """
+        monkeypatch.setattr(aimbat.settings, "event_duplicate_strict", True)
+        add_data_to_project(patched_session, [sac_file_good], data_type=DataType.SAC)
+        ambiguous = self._shifted_copy(sac_file_good, tmp_path, 1.0, "ambiguous.sac")
+
+        add_data_to_project(patched_session, [ambiguous], data_type=DataType.SAC)
+
+        assert len(patched_session.exec(select(AimbatEvent)).all()) == 2
 
 
 class TestGetDataSources:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from pandas import Timedelta
+from pydantic import ValidationError
 from rich.console import Console
 
 from aimbat._config import (
@@ -93,6 +95,29 @@ class TestSettings:
         """Verifies that context_width is a positive duration."""
         s = Settings()
         assert s.context_width.total_seconds() > 0
+
+    def test_event_duplicate_tolerance_default(self) -> None:
+        """Verifies the default event_duplicate_tolerance."""
+        s = Settings()
+        assert s.event_duplicate_tolerance == Timedelta(seconds=0.1)
+
+    def test_event_duplicate_raise_tolerance_default(self) -> None:
+        """Verifies the default event_duplicate_raise_tolerance."""
+        s = Settings()
+        assert s.event_duplicate_raise_tolerance == Timedelta(seconds=2)
+
+    def test_event_duplicate_strict_default(self) -> None:
+        """Verifies the default event_duplicate_strict."""
+        s = Settings()
+        assert s.event_duplicate_strict is False
+
+    def test_event_duplicate_raise_tolerance_must_exceed_tolerance(self) -> None:
+        """Verifies that an equal (or smaller) raise tolerance is rejected."""
+        with pytest.raises(ValidationError):
+            Settings(
+                event_duplicate_tolerance=Timedelta(seconds=1),
+                event_duplicate_raise_tolerance=Timedelta(seconds=1),
+            )
 
 
 class TestPrintSettingsTablePlain:


### PR DESCRIPTION
Detects near-duplicate AimbatEvent origin times on ingest instead of silently fragmenting one real event into several, driven by three new settings:

- `event_duplicate_tolerance` (default 0.1s): gap treated as ordinary timestamp precision noise; raises on a real add, warns on --dry-run.
- `event_duplicate_raise_tolerance` (default 2s): wider "ambiguous gap" band; raises unconditionally, even during --dry-run, since it usually signals a genuine timing problem in the source data rather than noise.
- `event_duplicate_strict`: skips both checks, falling back to exact microsecond-precision time matching only.

Detection covers same-batch near-duplicates (events created earlier in the same `data add` call), not just pre-existing ones, and the raise_tolerance boundary is exclusive — a gap of exactly raise_tolerance is independent, not ambiguous.

Also:
- Drop the dead, no-op `allow_mutation=False` Field kwarg (a Pydantic v1 argument with no effect under Pydantic v2/SQLModel) from six identity fields across AimbatEvent, AimbatSnapshot, and AimbatStation.
- Parameterize bare `os.PathLike`/`PathLike` and `set` generics across io/, core/_data.py, models/_models.py, and _cli/data.py.
- Expand docs/usage/data.md's event-matching and dry-run sections, and add titles to previously title-less admonitions across docs/.

<!-- readthedocs-preview aimbat start -->
----
📚 Documentation preview 📚: https://aimbat--251.org.readthedocs.build/en/251/

<!-- readthedocs-preview aimbat end -->