### PR TITLE
docs: render settings defaults via zensical macros instead of hand-ty…

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,5 +14,3 @@ permissions:
 jobs:
   deploy:
     uses: pysmo/.github/.github/workflows/docs.yml@main
-    with:
-      extra-build-command: uv run python -c "import sys; from aimbat._config import generate_settings_table_markdown as g; sys.stdout.write(g())" > docs/usage/defaults-table.md

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@ junit.xml
 .ipynb_checkpoints
 .envrc
 aimbat.log
-docs/usage/defaults-table.md
 .env
 aimbat_test*.log
 scratch/

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,7 +16,6 @@ build:
       - asdf global uv latest
       - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync --locked --no-dev --group docs
     post_build:
-      - uv run python -c "import sys; from aimbat._config import generate_settings_table_markdown as g; sys.stdout.write(g())" > docs/usage/defaults-table.md
       - uv run zensical build --clean
       - mkdir -p $READTHEDOCS_OUTPUT/html/
       - cp -r site/* $READTHEDOCS_OUTPUT/html/

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,6 @@ clean: ## Remove existing builds.
 	rm -rf build dist .egg aimbat.egg-info docs/build site
 
 docs: check-uv sync ## Build html docs.
-	uv run python -c "import sys; from aimbat._config import generate_settings_table_markdown as g; sys.stdout.write(g())" > docs/usage/defaults-table.md
 	uv run zensical build --clean
 
 format: check-uv ## Sort imports and format code.
@@ -59,7 +58,6 @@ lint: check-uv ## Run all linting checks.
 	uv run ruff format --check .
 
 live-docs: check-uv sync ## Live build html docs. They are served on http://localhost:8000
-	uv run python -c "import sys; from aimbat._config import generate_settings_table_markdown as g; sys.stdout.write(g())" > docs/usage/defaults-table.md
 	uv run zensical serve
 
 mypy: check-uv ## Run typing tests with pytest.

--- a/docs/usage/data.md
+++ b/docs/usage/data.md
@@ -84,13 +84,13 @@ possible near-duplicate. How close counts as "near" is controlled by
 `event_duplicate_tolerance` and `event_duplicate_raise_tolerance` (see
 [Aimbat Defaults](defaults.md)):
 
-- Within `event_duplicate_tolerance` (default 0.1 s), importing raises an
+- Within `event_duplicate_tolerance` (default {{ event_duplicate_tolerance }}), importing raises an
   error — or, during `--dry-run`, is reported as a warning instead — since a
   gap this small is usually timestamp precision loss upstream (e.g. the
   classic v6 SAC header's 32-bit float `o` field, which does not always
   round-trip identically across files) rather than a genuinely distinct
   event.
-- Beyond that but within `event_duplicate_raise_tolerance` (default 2 s),
+- Beyond that but within `event_duplicate_raise_tolerance` (default {{ event_duplicate_raise_tolerance }}),
   importing always raises, even during `--dry-run`, since a gap this size
   usually signals an actual timing problem in the source data worth
   investigating before import.

--- a/docs/usage/defaults.md
+++ b/docs/usage/defaults.md
@@ -13,7 +13,7 @@ be overridden on a per-project basis (in order of precedence):
 - A `.env`[^1] file in the current working directory (e.g.
     `AIMBAT_LOG_LEVEL=DEBUG`).
 
---8<-- "docs/usage/defaults-table.md"
+{{ settings_table }}
 
 !!! tip "Viewing the settings in effect"
 

--- a/main.py
+++ b/main.py
@@ -1,0 +1,26 @@
+"""zensical `macros` plugin entry point for the documentation build.
+
+Exposes AIMBAT `Settings` default values to Markdown pages as Jinja
+variables, so documentation never has to hand-type a value that could
+drift from `src/aimbat/_config.py`.
+"""
+
+from zensical.extensions.macros import MacroEnv
+
+from aimbat._config import generate_settings_table_markdown, get_default_settings
+
+
+def _format_seconds(seconds: float) -> str:
+    return f"{seconds:g} s"
+
+
+def define_env(env: MacroEnv) -> None:
+    """Register macro variables for use in documentation pages."""
+    settings = get_default_settings()
+    env.variables["event_duplicate_tolerance"] = _format_seconds(
+        settings.event_duplicate_tolerance.total_seconds()
+    )
+    env.variables["event_duplicate_raise_tolerance"] = _format_seconds(
+        settings.event_duplicate_raise_tolerance.total_seconds()
+    )
+    env.variables["settings_table"] = generate_settings_table_markdown()

--- a/src/aimbat/_config.py
+++ b/src/aimbat/_config.py
@@ -302,6 +302,35 @@ def cli_settings_list(
     print_settings_table(pretty)
 
 
+class _DefaultsOnly(Settings):
+    """Settings subclass that ignores environment variables and `.env` files.
+
+    Used to read field defaults uninfluenced by the current environment.
+    """
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        """Return no settings sources, so only field defaults apply."""
+        return ()
+
+
+def get_default_settings() -> Settings:
+    """Return AIMBAT settings populated from field defaults only.
+
+    Environment variables and `.env` files are ignored, so this reflects
+    the true default value of each setting regardless of the current
+    environment.
+    """
+    return _DefaultsOnly()
+
+
 def generate_settings_table_markdown() -> str:
     """Generate a Markdown table of all AIMBAT default settings.
 
@@ -311,26 +340,8 @@ def generate_settings_table_markdown() -> str:
     """
     import json
 
-    class _DefaultsOnly(Settings):
-        """Settings subclass that ignores environment variables and `.env` files.
-
-        Used to read field defaults uninfluenced by the current environment.
-        """
-
-        @classmethod
-        def settings_customise_sources(
-            cls,
-            settings_cls: type[BaseSettings],
-            init_settings: PydanticBaseSettingsSource,
-            env_settings: PydanticBaseSettingsSource,
-            dotenv_settings: PydanticBaseSettingsSource,
-            file_secret_settings: PydanticBaseSettingsSource,
-        ) -> tuple[PydanticBaseSettingsSource, ...]:
-            """Return no settings sources, so only field defaults apply."""
-            return ()
-
     env_prefix = Settings.model_config.get("env_prefix", "").upper()
-    values: dict[str, str] = json.loads(_DefaultsOnly().model_dump_json())
+    values: dict[str, str] = json.loads(get_default_settings().model_dump_json())
 
     lines = [
         "| Environment Variable | Default | Description |",

--- a/uv.lock
+++ b/uv.lock
@@ -980,14 +980,14 @@ wheels = [
 
 [[package]]
 name = "linkify-it-py"
-version = "2.1.0"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "uc-micro-py" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/3e/79f35b8c31a1881893b7e62be80b2573f06e38db47c33065749293ee1b97/linkify_it_py-2.1.1.tar.gz", hash = "sha256:a78f40fee177eb912e9d2375074108378523c38d3fde5d3ee804f465b6cfbfee", size = 30889, upload-time = "2026-08-24T17:16:57.028Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/3d/e34b19cd144071c583317268c4feb2c59c03ac57eef69753410c7abb11c0/linkify_it_py-2.1.1-py3-none-any.whl", hash = "sha256:8539a6b470efce90ba9b69e39b848e5b15b7ad89f7f98ca17d3532c243f987dc", size = 20532, upload-time = "2026-08-24T17:16:55.965Z" },
 ]
 
 [[package]]

--- a/zensical.toml
+++ b/zensical.toml
@@ -159,6 +159,7 @@ custom_fences = [
 ]
 [project.markdown_extensions.pymdownx.tabbed]
 alternate_style = true
+[project.plugins.macros]
 [project.plugins.mkdocstrings.handlers.python]
 paths = ["src"]
 inventories = [


### PR DESCRIPTION
…ping/shelling out

Adds the macros plugin with a main.py define_env() that exposes Settings defaults to Markdown pages. The two inline values in data.md no longer risk drifting from _config.py, and the settings table in defaults.md renders directly instead of being pre-generated by a shell one-liner duplicated across the Makefile, .readthedocs.yml, and the docs workflow.

<!-- readthedocs-preview aimbat start -->
----
📚 Documentation preview 📚: https://aimbat--252.org.readthedocs.build/en/252/

<!-- readthedocs-preview aimbat end -->