### PR TITLE
fix: address PR #256 review feedback

### DIFF
--- a/src/aimbat/_migrations/versions/20260902_0229_c7ba9d07fa0a_add_per_parent_unique_index_to_.py
+++ b/src/aimbat/_migrations/versions/20260902_0229_c7ba9d07fa0a_add_per_parent_unique_index_to_.py
@@ -30,7 +30,32 @@ depends_on: str | Sequence[str] | None = None
 _FK_COLUMNS = ("event_id", "station_id", "seismogram_id", "snapshot_id")
 
 
+def _reject_existing_duplicates() -> None:
+    """Fail with a clear message if the project already has duplicate notes.
+
+    `CREATE UNIQUE INDEX` on a table that already violates the constraint
+    raises an opaque "UNIQUE constraint failed" with no indication of which
+    rows are at fault - surface the offending parents instead.
+    """
+    bind = op.get_bind()
+    for column in _FK_COLUMNS:
+        rows = bind.execute(
+            sa.text(
+                f"SELECT {column} FROM aimbatnote WHERE {column} IS NOT NULL "
+                f"GROUP BY {column} HAVING COUNT(*) > 1"
+            )
+        ).fetchall()
+        if rows:
+            offenders = ", ".join(str(row[0]) for row in rows)
+            raise RuntimeError(
+                f"aimbatnote has more than one row for the same {column} "
+                f"({offenders}). Delete the duplicate note rows, keeping one "
+                f"per parent, then re-run `aimbat db upgrade`."
+            )
+
+
 def upgrade() -> None:
+    _reject_existing_duplicates()
     for column in _FK_COLUMNS:
         op.create_index(
             f"ix_aimbatnote_{column}",

--- a/src/aimbat/_tui/app.py
+++ b/src/aimbat/_tui/app.py
@@ -834,9 +834,10 @@ class AimbatTUI(_IccsLifecycleMixin, App[None]):
             return
 
         if tool in VIEW_ONLY_TOOLS:
-            # Nothing changed. suspend() is synchronous, so the staleness poller
-            # cannot fire between here and this assignment.
-            bound.created_at = Timestamp.now("UTC")
+            # A display-only tool changed nothing; just repaint. Deliberately
+            # leave bound.created_at alone - bumping it would mask an external
+            # commit (a CLI edit, an align worker) made while the plot window
+            # was open, so the staleness poller could no longer rebuild.
             self.refresh_all()
         else:
             # The tool persisted a parameter or pick change: the triggers have

--- a/src/aimbat/_types/_sqlalchemy.py
+++ b/src/aimbat/_types/_sqlalchemy.py
@@ -107,12 +107,23 @@ class SAPandasTimedelta(TypeDecorator):
 
         Returns:
             Duration in nanoseconds, or `None` if `value` is null.
+
+        Raises:
+            ValueError: If `value` is a non-null input that coerces to `NaT`
+                (e.g. the string `"NaT"`), matching `PydanticTimedelta`.
         """
         if pd.isnull(value):
             return None
 
+        result = coerce_to_timedelta(value)
+        if pd.isnull(result):
+            # A string like "NaT" slips past the null check above, but pandas
+            # parses it to a Timedelta NaT that would otherwise be stored as
+            # the iNaT sentinel integer.
+            raise ValueError("Timedelta value cannot be NaT")
+
         # Explicit int cast for safety with some SQL drivers
-        return int(coerce_to_timedelta(value).value)
+        return int(result.value)
 
     def process_result_value(self, value: Any, dialect: Dialect) -> Timedelta | None:
         """Convert a stored nanosecond count back to a `Timedelta`.

--- a/tests/functional/test_tui.py
+++ b/tests/functional/test_tui.py
@@ -1404,6 +1404,35 @@ class TestRunToolRebuildsIccs:
         self._run_with_tool(loaded_engine_from_file, monkeypatch, "stack", calls)
         assert calls == []
 
+    def test_view_only_tool_leaves_created_at_untouched(
+        self, loaded_engine_from_file: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Bumping created_at after a view-only tool would mask an external
+        commit made while the plot window was open, defeating the staleness
+        poller.
+        """
+        self._prepare(monkeypatch, loaded_engine_from_file)
+
+        async def _run() -> tuple[object, object]:
+            async with AimbatTUI().run_test(size=_TUI_SIZE) as pilot:
+                app = cast(AimbatTUI, pilot.app)
+                await _wait_for_iccs_worker(app)
+                with Session(loaded_engine_from_file) as session:
+                    event = session.exec(select(AimbatEvent)).first()
+                assert event is not None
+                app._current_event_id = event.id
+                app._create_iccs()
+                await _wait_for_iccs_worker(app)
+                bound = app._iccs_lifecycle.bound
+                assert bound is not None
+                before = bound.created_at
+                app._run_tool("stack", True, False, None)
+                await pilot.pause()
+                return before, bound.created_at
+
+        before, after = asyncio.run(_run())
+        assert before == after
+
 
 @pytest.mark.slow
 class TestToggleSeismogramBoolRefresh:

--- a/tests/integration/core/test_migrations.py
+++ b/tests/integration/core/test_migrations.py
@@ -288,6 +288,40 @@ class TestUpgradeProject:
         with pytest.raises(SchemaMismatchError):
             upgrade_project(engine_from_file)
 
+    def test_upgrade_fails_clearly_on_pre_existing_duplicate_notes(
+        self, engine_from_file: Engine
+    ) -> None:
+        """The per-parent-unique-index migration must name the offending
+        parent rather than raising a bare "UNIQUE constraint failed" when the
+        project already has two notes for the same event.
+        """
+        from alembic import command
+
+        from aimbat.core._migrations import _alembic_config
+
+        config = _alembic_config(engine_from_file)
+        command.upgrade(config, "ca35a8b78a91")  # one revision before the index
+
+        with engine_from_file.begin() as connection:
+            connection.execute(
+                text(
+                    "INSERT INTO aimbatevent (id, time, latitude, longitude) "
+                    "VALUES ('ev1', '2020-01-01 00:00:00', 0.0, 0.0)"
+                )
+            )
+            for note_id in ("n1", "n2"):
+                connection.execute(
+                    text(
+                        "INSERT INTO aimbatnote (id, content, event_id) "
+                        f"VALUES ('{note_id}', 'dupe', 'ev1')"
+                    )
+                )
+
+        with pytest.raises(
+            RuntimeError, match="more than one row for the same event_id"
+        ):
+            command.upgrade(config, "c7ba9d07fa0a")
+
     def test_upgrade_rejects_stamped_database_with_unrecognised_revision(
         self, engine_from_file: Engine
     ) -> None:

--- a/tests/unit/_types/test_sqlalchemy.py
+++ b/tests/unit/_types/test_sqlalchemy.py
@@ -163,6 +163,15 @@ class TestSAPandasTimedelta:
             seconds=-12.5
         )
 
+    def test_process_bind_param_rejects_nat_string(
+        self, sa_timedelta: SAPandasTimedelta, mock_dialect: Dialect
+    ) -> None:
+        """The string "NaT" coerces to a Timedelta NaT; reject it rather than
+        storing the iNaT sentinel integer - matching `PydanticTimedelta`.
+        """
+        with pytest.raises(ValueError, match="NaT"):
+            sa_timedelta.process_bind_param("NaT", mock_dialect)
+
     def test_process_result_value_none(
         self, sa_timedelta: SAPandasTimedelta, mock_dialect: Dialect
     ) -> None:


### PR DESCRIPTION
- SAPandasTimedelta.process_bind_param rejects the string "NaT" rather than storing the iNaT sentinel integer, matching PydanticTimedelta.
- Migration c7ba9d07fa0a preflights for pre-existing duplicate notes and raises a message naming the offending parent, instead of letting CREATE UNIQUE INDEX fail opaquely.
- View-only TUI tools (stack/image) no longer bump BoundICCS.created_at; it was masking external commits from the staleness poller.

<!-- readthedocs-preview aimbat start -->
----
📚 Documentation preview 📚: https://aimbat--257.org.readthedocs.build/en/257/

<!-- readthedocs-preview aimbat end -->