### PR TITLE
feat(iccs): separate stack-affecting changes and tighten the 1:1 links

### DIFF
--- a/src/aimbat/_migrations/versions/20260902_1751_4386151d11e2_unique_index_on_1_1_parameters_and_.py
+++ b/src/aimbat/_migrations/versions/20260902_1751_4386151d11e2_unique_index_on_1_1_parameters_and_.py
@@ -1,0 +1,72 @@
+"""unique index on 1:1 parameters and quality links
+
+Revision ID: 4386151d11e2
+Revises: d52a54a8a665
+Create Date: 2026-09-02 17:51:51.909907+00:00
+
+`AimbatSeismogramParameters` / `AimbatSeismogramQuality` are one row per
+seismogram, and `AimbatEventParameters` / `AimbatEventQuality` are one row
+per event - the ORM relationships are scalar - but nothing enforced it.
+A stray second row would be picked arbitrarily by helpers that build a
+`{parent_id: row}` map (e.g. `_snapshot._live_seismogram_quality_map`),
+silently yielding inconsistent reads. Add a unique index on each link
+column so a duplicate fails loudly at write time.
+
+Plain ``CREATE UNIQUE INDEX`` is used rather than ``batch_alter_table``:
+adding an index needs no table rebuild, and the batch rebuild would drop
+every trigger defined on these tables (triggers 1/3/4 on
+``aimbateventparameters``, 2/5a-c on ``aimbatseismogramparameters``).
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "4386151d11e2"
+down_revision: str | None = "d52a54a8a665"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# (table, link column) - the index is named ix_<table>_<column>.
+_UNIQUE_LINKS = (
+    ("aimbatseismogramparameters", "seismogram_id"),
+    ("aimbatseismogramquality", "seismogram_id"),
+    ("aimbateventparameters", "event_id"),
+    ("aimbateventquality", "event_id"),
+)
+
+
+def _reject_existing_duplicates() -> None:
+    """Fail with a clear message if a link column already has duplicate rows.
+
+    `CREATE UNIQUE INDEX` on a table that already violates the constraint
+    raises an opaque "UNIQUE constraint failed" with no indication of which
+    rows are at fault - surface the offending parents instead.
+    """
+    bind = op.get_bind()
+    for table, column in _UNIQUE_LINKS:
+        rows = bind.execute(
+            sa.text(
+                f"SELECT {column} FROM {table} GROUP BY {column} HAVING COUNT(*) > 1"
+            )
+        ).fetchall()
+        if rows:
+            offenders = ", ".join(str(row[0]) for row in rows)
+            raise RuntimeError(
+                f"{table} has more than one row for the same {column} "
+                f"({offenders}). Delete the duplicate rows, keeping one per "
+                f"parent, then re-run `aimbat db upgrade`."
+            )
+
+
+def upgrade() -> None:
+    _reject_existing_duplicates()
+    for table, column in _UNIQUE_LINKS:
+        op.create_index(f"ix_{table}_{column}", table, [column], unique=True)
+
+
+def downgrade() -> None:
+    for table, column in _UNIQUE_LINKS:
+        op.drop_index(f"ix_{table}_{column}", table_name=table)

--- a/src/aimbat/_migrations/versions/20260902_1852_2baa7d628f32_add_stack_modified_and_its_triggers.py
+++ b/src/aimbat/_migrations/versions/20260902_1852_2baa7d628f32_add_stack_modified_and_its_triggers.py
@@ -1,0 +1,88 @@
+"""add stack_modified and its triggers
+
+Revision ID: 2baa7d628f32
+Revises: 4386151d11e2
+Create Date: 2026-09-02 18:52:22.846693+00:00
+
+`aimbatevent.stack_modified` is bumped only by the parameter changes that
+alter the ICCS stack (event window / ramp / bandpass / corners, and
+per-seismogram t1 / flip / select), so an MCCC-only parameter change no
+longer forces an ICCS-instance rebuild. `last_modified` keeps tracking
+every parameter change and stays the general "repaint" signal.
+
+Triggers 1b and 2b below must stay byte-for-byte (modulo whitespace) in
+sync with core/_project.py::create_project() - checked by
+tests/integration/core/test_migrations.py::test_same_triggers. Plain
+``ALTER TABLE ADD COLUMN`` / ``CREATE TRIGGER`` are used, not
+``batch_alter_table``: neither needs a table rebuild.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+import aimbat._types
+
+# revision identifiers, used by Alembic.
+revision: str = "2baa7d628f32"
+down_revision: str | None = "4386151d11e2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_STACK_MODIFIED_ON_PARAMS_UPDATE = """
+    CREATE TRIGGER IF NOT EXISTS event_stack_modified_on_params_update
+    AFTER UPDATE ON aimbateventparameters
+    WHEN (NEW.window_pre IS NOT OLD.window_pre)
+      OR (NEW.window_post IS NOT OLD.window_post)
+      OR (NEW.ramp_width IS NOT OLD.ramp_width)
+      OR (NEW.bandpass_apply IS NOT OLD.bandpass_apply)
+      OR (NEW.bandpass_fmin IS NOT OLD.bandpass_fmin)
+      OR (NEW.bandpass_fmax IS NOT OLD.bandpass_fmax)
+      OR (NEW.corners IS NOT OLD.corners)
+    BEGIN
+        UPDATE aimbatevent SET stack_modified = strftime('%Y-%m-%d %H:%M:%f', 'now')
+        WHERE id = NEW.event_id;
+    END;
+"""
+
+_STACK_MODIFIED_ON_SEIS_PARAMS_UPDATE = """
+    CREATE TRIGGER IF NOT EXISTS event_stack_modified_on_seis_params_update
+    AFTER UPDATE ON aimbatseismogramparameters
+    WHEN (NEW.t1 IS NOT OLD.t1)
+      OR (NEW.flip IS NOT OLD.flip)
+      OR (NEW."select" IS NOT OLD."select")
+    BEGIN
+        UPDATE aimbatevent
+        SET stack_modified = strftime('%Y-%m-%d %H:%M:%f', 'now')
+        WHERE id = (
+            SELECT event_id FROM aimbatseismogram
+            WHERE id = NEW.seismogram_id
+        );
+    END;
+"""
+
+
+def upgrade() -> None:
+    op.add_column(
+        "aimbatevent",
+        sa.Column(
+            "stack_modified",
+            aimbat._types.SAPandasTimestamp(timezone=True),
+            nullable=True,
+        ),
+    )
+    # Seed from last_modified: existing instances treat the last parameter
+    # change as a possible stack change (conservative - at worst one extra
+    # rebuild on next open).
+    op.execute("UPDATE aimbatevent SET stack_modified = last_modified")
+    op.execute(sa.text(_STACK_MODIFIED_ON_PARAMS_UPDATE))
+    op.execute(sa.text(_STACK_MODIFIED_ON_SEIS_PARAMS_UPDATE))
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text("DROP TRIGGER IF EXISTS event_stack_modified_on_seis_params_update")
+    )
+    op.execute(sa.text("DROP TRIGGER IF EXISTS event_stack_modified_on_params_update"))
+    op.drop_column("aimbatevent", "stack_modified")

--- a/src/aimbat/_tui/_iccs_lifecycle.py
+++ b/src/aimbat/_tui/_iccs_lifecycle.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import uuid
 
+from pandas import Timestamp
 from sqlalchemy.exc import NoResultFound
 from sqlmodel import Session
 from textual import work
@@ -34,6 +35,11 @@ class _IccsLifecycleMixin(App[None]):
 
     _iccs_lifecycle: IccsLifecycle
 
+    # `event.last_modified` observed at the last staleness check, used to
+    # repaint panels (without rebuilding ICCS) after a non-stack parameter
+    # change (MCCC parameters or `min_cc`) made in another process.
+    _ui_last_modified_seen: Timestamp | None
+
     # Provided by AimbatTUI; declared here only so the type checker accepts
     # the calls below - the host class's own definitions take precedence.
     _current_event_id: uuid.UUID | None
@@ -47,6 +53,7 @@ class _IccsLifecycleMixin(App[None]):
     def _init_iccs_lifecycle(self) -> None:
         """Reset ICCS lifecycle state and start the periodic staleness check."""
         self._iccs_lifecycle = IccsLifecycle()
+        self._ui_last_modified_seen = None
         self.set_interval(5, self._check_iccs_staleness)
 
     def _create_iccs(self, *, is_retry: bool = False) -> None:
@@ -54,9 +61,10 @@ class _IccsLifecycleMixin(App[None]):
 
         ICCS construction reads waveform data, so it must not block the asyncio event loop.
         Concurrent calls are ignored — only one worker runs at a time. Also records the
-        current event's `last_modified` via `IccsLifecycle.note_checked`, so that a later
-        staleness poll correctly falls through to the one-shot retry branch instead of
-        treating the still-in-progress attempt as newly detected staleness.
+        current event's `stack_modified` via `IccsLifecycle.note_checked` (and its
+        `last_modified` for the UI-repaint check), so that a later staleness poll
+        correctly falls through to the one-shot retry branch instead of treating the
+        still-in-progress attempt as newly detected staleness.
 
         Args:
             is_retry: Whether this call is the one-shot retry made in
@@ -73,7 +81,8 @@ class _IccsLifecycleMixin(App[None]):
         try:
             with Session(engine) as session:
                 event = self._get_current_event(session)
-                self._iccs_lifecycle.note_checked(event.last_modified)
+                self._iccs_lifecycle.note_checked(event.stack_modified)
+                self._ui_last_modified_seen = event.last_modified
         except Exception:
             # Best-effort bookkeeping only — any failure here (no event
             # selected, a locked DB, ...) must not prevent the worker below
@@ -142,13 +151,16 @@ class _IccsLifecycleMixin(App[None]):
         self.refresh_all()
 
     def _check_iccs_staleness(self) -> None:
-        """Trigger ICCS recreation if the current event has been modified externally.
+        """React to an external change to the current event.
 
-        When ICCS creation previously failed (e.g. due to an invalid parameter set via
-        the CLI), retries once, then waits for `event.last_modified` to change again
-        before retrying further — this avoids retrying forever against a persistently
-        failing event. On any detected change the full UI is refreshed so panels
-        reflect the new DB state immediately.
+        A change to a stack-affecting parameter (`event.stack_modified`)
+        rebuilds the ICCS instance; any other parameter change
+        (`event.last_modified`, e.g. an MCCC-only tweak made via the CLI)
+        only repaints the panels so they reflect the new DB state. When ICCS
+        creation previously failed (e.g. an invalid parameter set via the
+        CLI), retries once, then waits for a further change before retrying
+        again — this avoids retrying forever against a persistently failing
+        event.
         """
         if self._current_event_id is None:
             return
@@ -156,8 +168,11 @@ class _IccsLifecycleMixin(App[None]):
             with Session(engine) as session:
                 event = self._get_current_event(session)
                 stale = self._iccs_lifecycle.is_stale(event)
+                last_modified = event.last_modified
         except (NoResultFound, RuntimeError):
             return
+        ui_changed = last_modified != self._ui_last_modified_seen
+        self._ui_last_modified_seen = last_modified
         if stale:
             logger.debug(
                 "ICCS staleness detected; recreating instance and refreshing UI."
@@ -167,6 +182,9 @@ class _IccsLifecycleMixin(App[None]):
         elif self._iccs_lifecycle.retry_pending:
             logger.debug("Retrying ICCS creation after a previous failure.")
             self._create_iccs(is_retry=True)
+            self.refresh_all()
+        elif ui_changed:
+            logger.debug("Event modified without a stack change; refreshing UI only.")
             self.refresh_all()
 
     def _require_iccs(self) -> bool:

--- a/src/aimbat/core/_iccs.py
+++ b/src/aimbat/core/_iccs.py
@@ -58,8 +58,8 @@ __all__ = [
 class BoundICCS:
     """An ICCS instance explicitly bound to a specific event.
 
-    Use `is_stale` to detect whether the event's parameters have been modified
-    (e.g. by a CLI command) since this instance was created.
+    Use `is_stale` to detect whether a stack-affecting parameter has been
+    modified (e.g. by a CLI command) since this instance was created.
     """
 
     iccs: ICCS
@@ -67,21 +67,22 @@ class BoundICCS:
     created_at: Timestamp
 
     def is_stale(self, event: AimbatEvent) -> bool:
-        """Return True if the event has been modified since this ICCS was created.
+        """Return True if this ICCS instance no longer matches the event.
 
         Args:
             event: The event to check against.
 
         Returns:
             True if `event.id` differs from the bound event, or if
-            `event.last_modified` has advanced since this instance was
-            created. False otherwise.
+            `event.stack_modified` has advanced since this instance was
+            created. An MCCC-only or `min_cc` change does not make it stale
+            (`run_iccs` refreshes `min_cc` on the instance per run).
         """
         if event.id != self.event_id:
             return True
-        if event.last_modified is None:
+        if event.stack_modified is None:
             return False
-        return event.last_modified > self.created_at
+        return event.stack_modified > self.created_at
 
 
 @dataclass
@@ -92,7 +93,7 @@ class IccsLifecycle:
     asynchronously without blocking a UI thread: an in-progress guard so
     overlapping creation attempts collapse into one, a one-shot retry flag
     for recovering from a transient failure, and a fallback staleness check
-    (`event.last_modified`) for the window before any instance exists yet.
+    (`event.stack_modified`) for the window before any instance exists yet.
 
     Callers own the actual I/O and threading (reading waveform data, running
     in a background thread, marshalling results back to a UI thread) and
@@ -102,7 +103,7 @@ class IccsLifecycle:
 
     bound: BoundICCS | None = None
     retry_pending: bool = False
-    last_modified_seen: Timestamp | None = None
+    stack_modified_seen: Timestamp | None = None
     _creating: bool = field(default=False, repr=False, init=False)
 
     @property
@@ -111,10 +112,10 @@ class IccsLifecycle:
         return self.bound is not None
 
     def is_stale(self, event: AimbatEvent) -> bool:
-        """Return True if the bound instance (or lack of one) needs refreshing.
+        """Return True if the bound instance (or lack of one) needs rebuilding.
 
         Delegates to `BoundICCS.is_stale` when an instance exists; otherwise
-        falls back to comparing `event.last_modified` against the value last
+        falls back to comparing `event.stack_modified` against the value last
         recorded via `note_checked`.
 
         Args:
@@ -122,7 +123,7 @@ class IccsLifecycle:
         """
         if self.bound is not None:
             return self.bound.is_stale(event)
-        return event.last_modified != self.last_modified_seen
+        return event.stack_modified != self.stack_modified_seen
 
     def start_creating(self) -> bool:
         """Begin a creation attempt, discarding any existing bound instance.
@@ -172,13 +173,13 @@ class IccsLifecycle:
         """
         self.bound = None
 
-    def note_checked(self, last_modified: Timestamp | None) -> None:
-        """Record the `last_modified` value observed at a staleness check.
+    def note_checked(self, stack_modified: Timestamp | None) -> None:
+        """Record the `stack_modified` value observed at a staleness check.
 
         Only meaningful while `bound` is `None`; used by `is_stale` to
         detect further changes before a new instance can be created.
         """
-        self.last_modified_seen = last_modified
+        self.stack_modified_seen = stack_modified
 
 
 @dataclass(frozen=True)
@@ -273,6 +274,9 @@ def _build_iccs(
         bandpass_fmin=p.bandpass_fmin,
         bandpass_fmax=p.bandpass_fmax,
         corners=p.corners,
+        # The autoselect threshold. Baked in here and refreshed per run in
+        # `run_iccs` - a bare `min_cc` change does not rebuild the instance
+        # (it does not touch the stack; see trigger 1b in core/_project.py).
         min_cc=p.min_cc,
         context_width=settings.context_width,
     )
@@ -281,7 +285,7 @@ def _build_iccs(
 def create_iccs_instance(session: Session, event: AimbatEvent) -> BoundICCS:
     """Return a BoundICCS instance for the given event.
 
-    Returns the cached instance when it is still fresh (i.e. `event.last_modified`
+    Returns the cached instance when it is still fresh (i.e. `event.stack_modified`
     has not advanced since the instance was created). Otherwise builds a new one
     and updates the cache. ICCS CC values are written to the live quality table in
     a separate session so the caller's session is not affected.
@@ -338,7 +342,7 @@ def _find_seismogram_quality(
         select(AimbatSeismogramQuality).where(
             col(AimbatSeismogramQuality.seismogram_id) == seismogram_id
         )
-    ).first()
+    ).one_or_none()
 
 
 def _write_iccs_stats(event_id: UUID, iccs: ICCS) -> None:
@@ -418,7 +422,7 @@ def _write_mccc_quality(
             select(AimbatEventQuality).where(
                 col(AimbatEventQuality.event_id) == event_id
             )
-        ).first()
+        ).one_or_none()
         if existing_eq is None:
             eq = AimbatEventQuality(
                 id=uuid4(), event_id=event_id, mccc_rmse=result.rmse
@@ -672,6 +676,11 @@ def run_iccs(
 
     logger.info(f"Running ICCS (autoflip={autoflip}, autoselect={autoselect}).")
 
+    # `min_cc` is stored on the instance at construction and, unlike the MCCC
+    # parameters, is not re-read per call. A bare `min_cc` change does not
+    # rebuild the instance (it does not affect the stack), so refresh it here
+    # before an autoselect run picks up a stale threshold.
+    iccs.min_cc = event.parameters.min_cc
     result = iccs(autoflip=autoflip, autoselect=autoselect)
     n_iter = len(result.convergence)
     status = "converged" if result.converged else "did not converge"

--- a/src/aimbat/core/_project.py
+++ b/src/aimbat/core/_project.py
@@ -82,9 +82,10 @@ def create_project(engine: Engine) -> None:
             # Trigger 1: Track last modification time when event parameters change.
             # Lists every event parameter except `completed`, which is bookkeeping
             # with no effect on ICCS/MCCC processing (it is likewise excluded from
-            # the snapshot parameter hashes in core/_snapshot.py). NB this is a
-            # superset of either hash's inputs — an MCCC-only parameter change
-            # bumps `last_modified` even though the ICCS stack is unchanged.
+            # the snapshot parameter hashes in core/_snapshot.py). `last_modified`
+            # is the general "something changed, repaint" signal for the TUI; the
+            # narrower `stack_modified` (triggers 1b/2b) is what drives ICCS
+            # staleness.
             connection.execute(
                 text("""
                 CREATE TRIGGER IF NOT EXISTS event_modified_on_params_update
@@ -114,6 +115,51 @@ def create_project(engine: Engine) -> None:
                 BEGIN
                     UPDATE aimbatevent
                     SET last_modified = strftime('%Y-%m-%d %H:%M:%f', 'now')
+                    WHERE id = (
+                        SELECT event_id FROM aimbatseismogram
+                        WHERE id = NEW.seismogram_id
+                    );
+                END;
+            """)
+            )
+
+            # Trigger 1b: Track when an event parameter that changes the ICCS
+            # stack is modified. This is the subset of trigger 1's columns that
+            # actually alter the aligned signal - matching trigger 3's WHEN
+            # clause - so `stack_modified` (and therefore ICCS-instance
+            # staleness) is not bumped by an MCCC-only or `min_cc` change.
+            # `min_cc` only feeds the autoselect threshold, which `run_iccs`
+            # refreshes on the instance per run.
+            connection.execute(
+                text("""
+                CREATE TRIGGER IF NOT EXISTS event_stack_modified_on_params_update
+                AFTER UPDATE ON aimbateventparameters
+                WHEN (NEW.window_pre IS NOT OLD.window_pre)
+                  OR (NEW.window_post IS NOT OLD.window_post)
+                  OR (NEW.ramp_width IS NOT OLD.ramp_width)
+                  OR (NEW.bandpass_apply IS NOT OLD.bandpass_apply)
+                  OR (NEW.bandpass_fmin IS NOT OLD.bandpass_fmin)
+                  OR (NEW.bandpass_fmax IS NOT OLD.bandpass_fmax)
+                  OR (NEW.corners IS NOT OLD.corners)
+                BEGIN
+                    UPDATE aimbatevent SET stack_modified = strftime('%Y-%m-%d %H:%M:%f', 'now')
+                    WHERE id = NEW.event_id;
+                END;
+            """)
+            )
+
+            # Trigger 2b: Track when a per-seismogram parameter that changes the
+            # ICCS stack (t1, flip, select) is modified.
+            connection.execute(
+                text("""
+                CREATE TRIGGER IF NOT EXISTS event_stack_modified_on_seis_params_update
+                AFTER UPDATE ON aimbatseismogramparameters
+                WHEN (NEW.t1 IS NOT OLD.t1)
+                  OR (NEW.flip IS NOT OLD.flip)
+                  OR (NEW."select" IS NOT OLD."select")
+                BEGIN
+                    UPDATE aimbatevent
+                    SET stack_modified = strftime('%Y-%m-%d %H:%M:%f', 'now')
                     WHERE id = (
                         SELECT event_id FROM aimbatseismogram
                         WHERE id = NEW.seismogram_id

--- a/src/aimbat/core/_snapshot.py
+++ b/src/aimbat/core/_snapshot.py
@@ -408,9 +408,10 @@ def _live_seismogram_quality_map(
 
     Keyed on the `seismogram_id` stored on each quality snapshot rather than
     its (possibly NULL) FK to the live quality row, so a snapshot still resolves
-    to the live records after the source quality row has been recreated. Relies
-    on the one-quality-row-per-seismogram invariant that
-    `AimbatSeismogram.quality` (a scalar relationship) assumes everywhere.
+    to the live records after the source quality row has been recreated. The
+    one-quality-row-per-seismogram invariant (`AimbatSeismogram.quality` is a
+    scalar relationship) is enforced by a unique index on
+    `AimbatSeismogramQuality.seismogram_id`.
     """
     seismogram_ids = {
         q.seismogram_id

--- a/src/aimbat/models/_models.py
+++ b/src/aimbat/models/_models.py
@@ -110,6 +110,14 @@ class AimbatSeismogramParameters(AimbatSeismogramParametersBase, table=True):
         populate_by_name=True,
     )
 
+    __table_args__ = (
+        Index(
+            "ix_aimbatseismogramparameters_seismogram_id",
+            "seismogram_id",
+            unique=True,
+        ),
+    )
+
     id: uuid.UUID = Field(
         default_factory=uuid.uuid4,
         primary_key=True,
@@ -184,6 +192,10 @@ class AimbatEventParameters(AimbatEventParametersBase, table=True):
     model_config = SQLModelConfig(
         alias_generator=to_camel,
         populate_by_name=True,
+    )
+
+    __table_args__ = (
+        Index("ix_aimbateventparameters_event_id", "event_id", unique=True),
     )
 
     id: uuid.UUID = Field(
@@ -263,6 +275,14 @@ class AimbatSeismogramQuality(AimbatSeismogramQualityBase, table=True):
         populate_by_name=True,
     )
 
+    __table_args__ = (
+        Index(
+            "ix_aimbatseismogramquality_seismogram_id",
+            "seismogram_id",
+            unique=True,
+        ),
+    )
+
     id: uuid.UUID = Field(
         default_factory=uuid.uuid4, primary_key=True, description="Unique ID."
     )
@@ -335,6 +355,8 @@ class AimbatEventQuality(AimbatEventQualityBase, table=True):
         alias_generator=to_camel,
         populate_by_name=True,
     )
+
+    __table_args__ = (Index("ix_aimbateventquality_event_id", "event_id", unique=True),)
 
     id: uuid.UUID = Field(
         default_factory=uuid.uuid4, primary_key=True, description="Unique ID."
@@ -670,6 +692,18 @@ class AimbatEvent(SQLModel, table=True):
         sa_type=SAPandasTimestamp,
         title="Last modified",
         description="Timestamp of the last parameter modification.",
+    )
+    stack_modified: PydanticTimestamp | None = Field(
+        default=None,
+        sa_type=SAPandasTimestamp,
+        title="Stack modified",
+        description=(
+            "Timestamp of the last change to a parameter that requires the "
+            "ICCS instance to be rebuilt (event window, ramp, bandpass, "
+            "corners; per-seismogram t1, flip, select). Drives "
+            "`BoundICCS.is_stale`. Unlike `last_modified`, an MCCC-only or "
+            "`min_cc` change does not bump it."
+        ),
     )
     seismograms: list[AimbatSeismogram] = Relationship(
         back_populates="event", cascade_delete=True

--- a/tests/functional/test_tui.py
+++ b/tests/functional/test_tui.py
@@ -382,7 +382,7 @@ class TestICCSStalenessRetry:
     See `AimbatTUI._check_iccs_staleness` / `_create_iccs`: a fresh (non-retry)
     failure sets `IccsLifecycle.retry_pending`, which the staleness poller
     consumes at most once before falling silent again until
-    `event.last_modified` changes.
+    `event.stack_modified` changes.
     """
 
     def test_retries_once_then_stops_on_persistent_failure(
@@ -417,8 +417,8 @@ class TestICCSStalenessRetry:
                 assert event is not None
                 app._current_event_id = event.id
                 # Mirror what `_check_iccs_staleness` records before a fresh
-                # attempt, so later polls see an unchanged `last_modified`.
-                app._iccs_lifecycle.note_checked(event.last_modified)
+                # attempt, so later polls see an unchanged `stack_modified`.
+                app._iccs_lifecycle.note_checked(event.stack_modified)
 
                 app._create_iccs()
                 await _wait_for_iccs_worker(app)
@@ -473,7 +473,7 @@ class TestICCSStalenessRetry:
                     event = session.exec(select(AimbatEvent)).first()
                 assert event is not None
                 app._current_event_id = event.id
-                app._iccs_lifecycle.note_checked(event.last_modified)
+                app._iccs_lifecycle.note_checked(event.stack_modified)
 
                 app._create_iccs()
                 await _wait_for_iccs_worker(app)
@@ -507,7 +507,7 @@ class TestICCSStalenessRetry:
         class _SimulatedError(Exception):
             pass
 
-        def _always_raises(self: IccsLifecycle, last_modified: object) -> None:
+        def _always_raises(self: IccsLifecycle, stack_modified: object) -> None:
             raise _SimulatedError("simulated failure recording note_checked")
 
         monkeypatch.setattr(IccsLifecycle, "note_checked", _always_raises)
@@ -537,6 +537,59 @@ class TestICCSStalenessRetry:
 
 
 @pytest.mark.slow
+class TestStalenessUIRefresh:
+    """An external non-stack parameter change repaints the panels without
+    rebuilding the ICCS instance. See `_IccsLifecycleMixin._check_iccs_staleness`.
+    """
+
+    def test_mccc_param_change_refreshes_ui_without_rebuilding_iccs(
+        self, loaded_engine_from_file: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_engine(monkeypatch, loaded_engine_from_file)
+
+        async def _run() -> None:
+            async with AimbatTUI().run_test(size=_TUI_SIZE) as pilot:
+                app = cast(AimbatTUI, pilot.app)
+                await _wait_for_iccs_worker(app)
+
+                with Session(loaded_engine_from_file) as session:
+                    event = session.exec(select(AimbatEvent)).first()
+                assert event is not None
+                app._current_event_id = event.id
+                app._create_iccs()
+                await _wait_for_iccs_worker(app)
+                bound_before = app._iccs_lifecycle.bound
+                assert bound_before is not None
+
+                refreshes: list[str] = []
+                monkeypatch.setattr(
+                    AimbatTUI, "refresh_all", lambda self: refreshes.append("r")
+                )
+                rebuilds: list[str] = []
+                monkeypatch.setattr(
+                    AimbatTUI,
+                    "_create_iccs",
+                    lambda self, *, is_retry=False: rebuilds.append("c"),
+                )
+
+                # Another process bumps an MCCC-only parameter.
+                with Session(loaded_engine_from_file) as session:
+                    ev = session.get(AimbatEvent, event.id)
+                    assert ev is not None
+                    ev.parameters.mccc_damp = ev.parameters.mccc_damp + 0.5
+                    session.add(ev.parameters)
+                    session.commit()
+
+                app._check_iccs_staleness()
+                await pilot.pause()
+
+                assert refreshes == ["r"]
+                assert rebuilds == []
+                assert app._iccs_lifecycle.bound is bound_before
+
+        asyncio.run(_run())
+
+
 class TestIccsAssignmentRace:
     """A worker completing for an event that is no longer current is discarded.
 

--- a/tests/integration/core/test_iccs.py
+++ b/tests/integration/core/test_iccs.py
@@ -159,6 +159,31 @@ class TestIccsMcccInterplay:
                 assert s.quality is not None
                 assert s.quality.iccs_cc is None
 
+    def test_run_iccs_refreshes_min_cc_from_db(self, loaded_session: Session) -> None:
+        """A `min_cc` change does not rebuild the ICCS instance (it is not a
+        stack change), so `run_iccs` must refresh the autoselect threshold on
+        the instance before running - otherwise an autoselect run uses the
+        stale value baked in at construction."""
+        event = loaded_session.exec(select(AimbatEvent)).first()
+        assert event is not None
+
+        iccs_bound = create_iccs_instance(loaded_session, event)
+        assert iccs_bound.iccs.min_cc == event.parameters.min_cc
+
+        event.parameters.min_cc = 0.123
+        loaded_session.add(event.parameters)
+        loaded_session.commit()
+
+        # The instance is unchanged by the bare threshold edit...
+        assert not iccs_bound.is_stale(event)
+        assert iccs_bound.iccs.min_cc != 0.123
+
+        # ...but run_iccs picks it up.
+        run_iccs(
+            loaded_session, event, iccs_bound.iccs, autoflip=False, autoselect=True
+        )
+        assert iccs_bound.iccs.min_cc == 0.123
+
 
 class TestCcStats:
     """Tests for `core.cc_stats`."""

--- a/tests/integration/core/test_migrations.py
+++ b/tests/integration/core/test_migrations.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 from sqlalchemy import Engine, create_engine, event, inspect, text
+from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, select
 
 import aimbat._migrations
@@ -541,6 +542,182 @@ class TestUpgradeProject:
                 ).scalar()
                 == 1
             )
+
+    def test_one_to_one_link_index_rejects_duplicate_after_migration(
+        self, engine_from_file: Engine
+    ) -> None:
+        """`CREATE UNIQUE INDEX` on the link column makes a second row for one
+        parent fail at write time (checked on `aimbatseismogramquality`; the
+        four columns share one migration)."""
+        from alembic import command
+
+        from aimbat.core._migrations import _alembic_config
+
+        config = _alembic_config(engine_from_file)
+        command.upgrade(config, "4386151d11e2")
+
+        with engine_from_file.begin() as connection:
+            connection.execute(
+                text(
+                    "INSERT INTO aimbatevent (id, time, latitude, longitude) "
+                    "VALUES ('ev1', '2020-01-01 00:00:00', 0.0, 0.0)"
+                )
+            )
+            connection.execute(
+                text(
+                    "INSERT INTO aimbatstation (id, name, network, location, channel, "
+                    "latitude, longitude) VALUES "
+                    "('st1', 'AAK', 'II', '00', 'BHZ', 0.0, 0.0)"
+                )
+            )
+            connection.execute(
+                text(
+                    "INSERT INTO aimbatseismogram "
+                    "(id, begin_time, delta, t0, event_id, station_id) VALUES "
+                    "('se1', '2020-01-01 00:00:00', 50000000, "
+                    "'2020-01-01 00:00:00', 'ev1', 'st1')"
+                )
+            )
+            connection.execute(
+                text(
+                    "INSERT INTO aimbatseismogramquality (id, seismogram_id) "
+                    "VALUES ('sq1', 'se1')"
+                )
+            )
+
+        with pytest.raises(IntegrityError):
+            with engine_from_file.begin() as connection:
+                connection.execute(
+                    text(
+                        "INSERT INTO aimbatseismogramquality (id, seismogram_id) "
+                        "VALUES ('sq2', 'se1')"
+                    )
+                )
+
+    def test_one_to_one_link_migration_fails_clearly_on_existing_duplicate(
+        self, engine_from_file: Engine
+    ) -> None:
+        """A project that already has two quality rows for one seismogram
+        must get a message naming the seismogram, not a bare
+        "UNIQUE constraint failed"."""
+        from alembic import command
+
+        from aimbat.core._migrations import _alembic_config
+
+        config = _alembic_config(engine_from_file)
+        command.upgrade(config, "d52a54a8a665")  # one revision before the index
+
+        with engine_from_file.begin() as connection:
+            connection.execute(
+                text(
+                    "INSERT INTO aimbatevent (id, time, latitude, longitude) "
+                    "VALUES ('ev1', '2020-01-01 00:00:00', 0.0, 0.0)"
+                )
+            )
+            connection.execute(
+                text(
+                    "INSERT INTO aimbatstation (id, name, network, location, channel, "
+                    "latitude, longitude) VALUES "
+                    "('st1', 'AAK', 'II', '00', 'BHZ', 0.0, 0.0)"
+                )
+            )
+            connection.execute(
+                text(
+                    "INSERT INTO aimbatseismogram "
+                    "(id, begin_time, delta, t0, event_id, station_id) VALUES "
+                    "('se1', '2020-01-01 00:00:00', 50000000, "
+                    "'2020-01-01 00:00:00', 'ev1', 'st1')"
+                )
+            )
+            for row_id in ("sq1", "sq2"):
+                connection.execute(
+                    text(
+                        "INSERT INTO aimbatseismogramquality (id, seismogram_id) "
+                        f"VALUES ('{row_id}', 'se1')"
+                    )
+                )
+
+        with pytest.raises(
+            RuntimeError, match="more than one row for the same seismogram_id"
+        ):
+            command.upgrade(config, "4386151d11e2")
+
+    def test_stack_modified_seeded_from_last_modified(
+        self, engine_from_file: Engine
+    ) -> None:
+        """The new `stack_modified` column is backfilled from `last_modified`."""
+        from alembic import command
+
+        from aimbat.core._migrations import _alembic_config
+
+        config = _alembic_config(engine_from_file)
+        command.upgrade(config, "4386151d11e2")  # one revision before stack_modified
+
+        with engine_from_file.begin() as connection:
+            connection.execute(
+                text(
+                    "INSERT INTO aimbatevent "
+                    "(id, time, latitude, longitude, last_modified) VALUES "
+                    "('ev1', '2020-01-01 00:00:00', 0.0, 0.0, '2021-06-01 12:00:00'), "
+                    "('ev2', '2020-02-01 00:00:00', 0.0, 0.0, NULL)"
+                )
+            )
+
+        command.upgrade(config, "2baa7d628f32")
+
+        with engine_from_file.begin() as connection:
+            rows = {
+                row[0]: (row[1], row[2])
+                for row in connection.execute(
+                    text("SELECT id, last_modified, stack_modified FROM aimbatevent")
+                ).all()
+            }
+        assert rows["ev1"][1] == rows["ev1"][0]
+        assert rows["ev2"][1] is None
+
+    def test_stack_modified_trigger_ignores_mccc_params_after_migration(
+        self, engine_from_file: Engine
+    ) -> None:
+        """Post-migration, an MCCC-only parameter change bumps `last_modified`
+        but not `stack_modified`."""
+        from alembic import command
+
+        from aimbat.core._migrations import _alembic_config
+
+        config = _alembic_config(engine_from_file)
+        command.upgrade(config, "2baa7d628f32")
+
+        with engine_from_file.begin() as connection:
+            connection.execute(
+                text(
+                    "INSERT INTO aimbatevent (id, time, latitude, longitude) "
+                    "VALUES ('ev1', '2020-01-01 00:00:00', 0.0, 0.0)"
+                )
+            )
+            connection.execute(
+                text(
+                    "INSERT INTO aimbateventparameters "
+                    "(id, event_id, completed, ramp_width, window_pre, window_post, "
+                    "bandpass_apply, bandpass_fmin, bandpass_fmax, min_cc, mccc_damp, "
+                    "mccc_min_cc, corners) VALUES "
+                    "('ep1', 'ev1', 0, 0.1, -1000000000, 1000000000, 0, 0.1, 1.0, "
+                    "0.5, 1.0, 0.5, 2)"
+                )
+            )
+            connection.execute(
+                text(
+                    "UPDATE aimbateventparameters SET mccc_damp = 5.0 WHERE id = 'ep1'"
+                )
+            )
+            row = connection.execute(
+                text(
+                    "SELECT last_modified, stack_modified FROM aimbatevent "
+                    "WHERE id = 'ev1'"
+                )
+            ).one()
+
+        assert row.last_modified is not None
+        assert row.stack_modified is None
 
     def test_upgrade_rejects_stamped_database_with_unrecognised_revision(
         self, engine_from_file: Engine

--- a/tests/integration/models/test_models.py
+++ b/tests/integration/models/test_models.py
@@ -646,3 +646,60 @@ class TestUniqueConstraints:
 
         events = patched_session.exec(select(AimbatEvent)).all()
         assert len(events) == 2
+
+
+class TestOneToOneLinkConstraints:
+    """The parameters/quality tables are one row per parent - a unique index
+    on the link column enforces it."""
+
+    def test_second_seismogram_parameters_rejected(
+        self, patched_session: Session
+    ) -> None:
+        from sqlalchemy.exc import IntegrityError
+
+        ev = _make_event(patched_session)
+        sta = _make_station(patched_session)
+        seis = _make_seismogram(patched_session, ev, sta)
+        patched_session.commit()
+
+        patched_session.add(AimbatSeismogramParameters(seismogram=seis))
+        with pytest.raises(IntegrityError):
+            patched_session.flush()
+
+    def test_second_seismogram_quality_rejected(self, patched_session: Session) -> None:
+        from sqlalchemy.exc import IntegrityError
+
+        ev = _make_event(patched_session)
+        sta = _make_station(patched_session)
+        seis = _make_seismogram(patched_session, ev, sta)
+        patched_session.add(AimbatSeismogramQuality(seismogram=seis, iccs_cc=0.8))
+        patched_session.commit()
+
+        patched_session.add(AimbatSeismogramQuality(seismogram=seis, iccs_cc=0.5))
+        with pytest.raises(IntegrityError):
+            patched_session.flush()
+
+    def test_second_event_parameters_rejected(self, patched_session: Session) -> None:
+        from sqlalchemy.exc import IntegrityError
+
+        ev = _make_event(patched_session)
+        patched_session.commit()
+
+        patched_session.add(AimbatEventParameters(event=ev))
+        with pytest.raises(IntegrityError):
+            patched_session.flush()
+
+    def test_second_event_quality_rejected(self, patched_session: Session) -> None:
+        from sqlalchemy.exc import IntegrityError
+
+        ev = _make_event(patched_session)
+        patched_session.add(
+            AimbatEventQuality(event=ev, mccc_rmse=Timedelta(milliseconds=1))
+        )
+        patched_session.commit()
+
+        patched_session.add(
+            AimbatEventQuality(event=ev, mccc_rmse=Timedelta(milliseconds=2))
+        )
+        with pytest.raises(IntegrityError):
+            patched_session.flush()

--- a/tests/integration/models/test_triggers.py
+++ b/tests/integration/models/test_triggers.py
@@ -4,6 +4,7 @@ from pandas import Timedelta, Timestamp
 from sqlmodel import Session, select
 
 from aimbat.models import (
+    AimbatEvent,
     AimbatEventQuality,
     AimbatSeismogram,
     AimbatSeismogramQuality,
@@ -230,3 +231,57 @@ def test_trigger_null_event_quality_on_select_change(loaded_session: Session) ->
     assert event_quality.mccc_rmse is None
 
     # TODO: Add application-level logic to null seismogram quality metrics
+
+
+def _event_with_params(session: Session) -> AimbatEvent:
+    seis = session.exec(select(AimbatSeismogram)).first()
+    assert seis is not None
+    return seis.event
+
+
+def test_trigger_stack_modified_bumped_by_window_change(
+    loaded_session: Session,
+) -> None:
+    """A window change alters the aligned signal, so it bumps `stack_modified`."""
+    event = _event_with_params(loaded_session)
+    assert event.stack_modified is None
+
+    event.parameters.window_pre = event.parameters.window_pre - Timedelta(seconds=1)
+    loaded_session.add(event.parameters)
+    loaded_session.commit()
+
+    loaded_session.refresh(event)
+    assert event.stack_modified is not None
+
+
+def test_trigger_stack_modified_not_bumped_by_mccc_param_change(
+    loaded_session: Session,
+) -> None:
+    """An MCCC-only parameter leaves the ICCS stack unchanged: `last_modified`
+    bumps (general repaint signal) but `stack_modified` does not."""
+    event = _event_with_params(loaded_session)
+    assert event.stack_modified is None
+
+    event.parameters.mccc_damp = event.parameters.mccc_damp + 0.5
+    loaded_session.add(event.parameters)
+    loaded_session.commit()
+
+    loaded_session.refresh(event)
+    assert event.last_modified is not None
+    assert event.stack_modified is None
+
+
+def test_trigger_stack_modified_bumped_by_seismogram_t1_change(
+    loaded_session: Session,
+) -> None:
+    """A per-seismogram pick change alters the stack via that trace."""
+    seis = loaded_session.exec(select(AimbatSeismogram)).first()
+    assert seis is not None
+    assert seis.event.stack_modified is None
+
+    seis.parameters.t1 = Timestamp("2011-01-01T00:00:05", tz="UTC")
+    loaded_session.add(seis.parameters)
+    loaded_session.commit()
+
+    loaded_session.refresh(seis.event)
+    assert seis.event.stack_modified is not None

--- a/tests/unit/core/test_iccs_lifecycle.py
+++ b/tests/unit/core/test_iccs_lifecycle.py
@@ -17,7 +17,7 @@ from aimbat.models import AimbatEvent
 
 
 def _make_event(
-    *, event_id: uuid.UUID | None = None, last_modified: Timestamp | None = None
+    *, event_id: uuid.UUID | None = None, stack_modified: Timestamp | None = None
 ) -> AimbatEvent:
     """Build a detached AimbatEvent with just the fields IccsLifecycle reads."""
     return AimbatEvent(
@@ -25,7 +25,7 @@ def _make_event(
         time=Timestamp("2020-01-01T00:00:00", tz="UTC"),
         latitude=0.0,
         longitude=0.0,
-        last_modified=last_modified,
+        stack_modified=stack_modified,
     )
 
 
@@ -53,18 +53,18 @@ class TestReady:
 class TestIsStale:
     """Tests for IccsLifecycle.is_stale."""
 
-    def test_no_bound_instance_falls_back_to_last_modified_seen(self) -> None:
+    def test_no_bound_instance_falls_back_to_stack_modified_seen(self) -> None:
         """With no bound instance, staleness compares against note_checked's value."""
         lifecycle = IccsLifecycle()
-        event = _make_event(last_modified=Timestamp("2020-01-01T00:00:00", tz="UTC"))
+        event = _make_event(stack_modified=Timestamp("2020-01-01T00:00:00", tz="UTC"))
 
         # Nothing recorded yet -> considered stale.
         assert lifecycle.is_stale(event) is True
 
-        lifecycle.note_checked(event.last_modified)
+        lifecycle.note_checked(event.stack_modified)
         assert lifecycle.is_stale(event) is False
 
-        event.last_modified = Timestamp("2020-01-02T00:00:00", tz="UTC")
+        event.stack_modified = Timestamp("2020-01-02T00:00:00", tz="UTC")
         assert lifecycle.is_stale(event) is True
 
     def test_bound_instance_delegates_to_bound_is_stale(self) -> None:
@@ -73,11 +73,11 @@ class TestIsStale:
         created_at = Timestamp("2020-01-01T00:00:00", tz="UTC")
         lifecycle = IccsLifecycle(bound=_make_bound(event_id, created_at))
 
-        fresh_event = _make_event(event_id=event_id, last_modified=None)
+        fresh_event = _make_event(event_id=event_id, stack_modified=None)
         assert lifecycle.is_stale(fresh_event) is False
 
         modified_event = _make_event(
-            event_id=event_id, last_modified=created_at + Timedelta(seconds=1)
+            event_id=event_id, stack_modified=created_at + Timedelta(seconds=1)
         )
         assert lifecycle.is_stale(modified_event) is True
 
@@ -181,11 +181,11 @@ class TestClear:
 class TestNoteChecked:
     """Tests for IccsLifecycle.note_checked."""
 
-    def test_updates_last_modified_seen(self) -> None:
+    def test_updates_stack_modified_seen(self) -> None:
         """The observed timestamp is recorded verbatim."""
         lifecycle = IccsLifecycle()
         ts = Timestamp("2020-01-01T00:00:00", tz="UTC")
 
         lifecycle.note_checked(ts)
 
-        assert lifecycle.last_modified_seen == ts
+        assert lifecycle.stack_modified_seen == ts


### PR DESCRIPTION
Two snapshot-redesign follow-ups:

- Unique index on the four 1:1 link columns (AimbatSeismogram{Parameters,Quality}.seismogram_id, AimbatEvent{Parameters,Quality}.event_id). The ORM relationships are scalar but nothing enforced it; a stray duplicate would be resolved arbitrarily by the {parent_id: row} map helpers. Migration 4386151d11e2 uses plain CREATE UNIQUE INDEX + a duplicate preflight, not a batch rebuild, so the triggers on those tables survive. The now-guaranteed lookups in _iccs.py use .one_or_none().

- New AimbatEvent.stack_modified, bumped by triggers 1b/2b only on the parameters that require an ICCS rebuild (event window / ramp / bandpass / corners; per-seismogram t1 / flip / select). BoundICCS.is_stale and IccsLifecycle key off it; last_modified is unchanged and stays the TUI's general repaint signal, so _check_iccs_staleness now repaints panels on a non-stack change without rebuilding ICCS. An MCCC-only or min_cc change no longer triggers a needless rebuild; run_iccs refreshes the min_cc autoselect threshold on the instance per run. Migration 2baa7d628f32.

<!-- readthedocs-preview aimbat start -->
----
📚 Documentation preview 📚: https://aimbat--259.org.readthedocs.build/en/259/

<!-- readthedocs-preview aimbat end -->