### PR TITLE
feat(data): reuse existing event within event_duplicate_tolerance

### DIFF
--- a/docs/snippets/api_deduplicate.py
+++ b/docs/snippets/api_deduplicate.py
@@ -9,10 +9,13 @@ Background
 even with different coordinates, always reuses the existing record.  Station
 duplicates therefore cannot arise through the normal import path.
 
-Events are deduplicated by exact origin time.  When two data sources report
-the same earthquake with origin times that differ by a second or two, they are
-stored as *separate* ``AimbatEvent`` records. This script finds such
-near-duplicate events, merges their seismograms into the canonical record
+Events are reused on an exact origin-time match, or when the gap is within
+``event_duplicate_tolerance`` (default 0.1 s).  When two data sources report
+the same earthquake with origin times that differ by more than that, they are
+stored as *separate* ``AimbatEvent`` records (a gap in the "ambiguous gap"
+band raises instead; only a gap beyond ``event_duplicate_raise_tolerance``
+creates the separate record silently). This script finds such near-duplicate
+events, merges their seismograms into the canonical record
 (the one with the most seismograms), averages the location and depth, then
 removes the duplicates.
 

--- a/docs/usage/api.md
+++ b/docs/usage/api.md
@@ -290,11 +290,15 @@ Models can be queried directly using SQLModel's `select`:
 `(network, name, location, channel)`, so importing the same station from
 multiple sources never creates duplicate records.
 
-Events are a different story: they are deduplicated by exact origin time. When
-two data sources report the same earthquake with times that differ by a second
-or two, they are stored as separate `AimbatEvent` records. The script below
-detects such near-duplicates, merges their seismograms into the record with the
-most data, averages the location and depth, and removes the extras.
+Events are a different story. Import reuses an existing event on an exact
+origin-time match, or when the gap is within `event_duplicate_tolerance`
+(default 0.1 s); a larger gap either raises (the "ambiguous gap" band) or,
+beyond `event_duplicate_raise_tolerance`, silently creates a separate
+`AimbatEvent` record. When two data sources report the same earthquake with
+times that differ by more than that, they end up as separate records. The
+script below detects such near-duplicates, merges their seismograms into the
+record with the most data, averages the location and depth, and removes the
+extras.
 
 ```python
 --8<-- "docs/snippets/api_deduplicate.py"

--- a/docs/usage/data.md
+++ b/docs/usage/data.md
@@ -82,16 +82,17 @@ AIMBAT links a SAC file to an existing event only if its origin time is
 AIMBAT stores timestamps at). Otherwise it does not reuse that event.
 
 A new origin time that nearly, but not exactly, matches an existing event's time
-is not silently turned into a second event. It is flagged as a possible
-near-duplicate. How close counts as "near" is controlled by
-`event_duplicate_tolerance` and `event_duplicate_raise_tolerance` (see
-[Aimbat Defaults](defaults.md)):
+is not silently turned into a second event. How close counts as "near" is
+controlled by `event_duplicate_tolerance` and `event_duplicate_raise_tolerance`
+(see [Aimbat Defaults](defaults.md)):
 
 - Within `event_duplicate_tolerance` (default {{ event_duplicate_tolerance }}),
-  a real import raises an error; a `--dry-run` reports a warning. A gap this
-  small is usually timestamp precision loss upstream, such as the classic v6 SAC
-  header's 32-bit float `o` field not round-tripping identically across files,
-  rather than a genuinely distinct event.
+  the existing event is reused, exactly as an exact time match is, with a
+  warning naming both origin times and the gap (a `--dry-run` reports the same
+  in its preview). A gap this small is usually timestamp precision loss
+  upstream, such as the classic v6 SAC header's 32-bit float `o` field not
+  round-tripping identically across files, rather than a genuinely distinct
+  event.
 - Beyond that but within `event_duplicate_raise_tolerance` (default
   {{ event_duplicate_raise_tolerance }}), import always raises, even during
   `--dry-run`. A gap this size usually signals a real timing problem in the
@@ -101,9 +102,10 @@ near-duplicate. How close counts as "near" is controlled by
 
 The check runs against every event AIMBAT already knows about when a file is
 processed, including events created earlier in the same `data add` call.
-Resolving a flag is always first-wins: re-run with `--use-event <ID>` to link
-the new file to the existing event's stored time and location exactly as they
-are. It never merges, averages, or recomputes from the new file.
+Reuse is always first-wins: the new file links to the existing event's stored
+time and location exactly as they are. It never merges, averages, or recomputes
+from the new file. In the ambiguous-gap band, re-run with `--use-event <ID>` to
+link explicitly to the existing event and get past the error.
 
 !!! warning "Use SAC header version 7, or provide the event explicitly"
 
@@ -130,14 +132,15 @@ aimbat data add --dry-run *.sac
 ```
 
 It prints which stations, events, and seismograms would be newly created versus
-already known, and shows any near-duplicate warnings a real run would raise. That
-makes it worth running as routine practice before a new batch: catching a flagged
-near-duplicate here means resolving it up front with `--use-event <ID>` rather
-than hitting it partway through a real import, which aborts the whole batch and
-rolls back everything already added in that call.
+already known (a near-duplicate within `event_duplicate_tolerance` shows as a
+reused event), and surfaces any ambiguous-gap conflict a real run would raise.
+That makes it worth running as routine practice before a new batch: catching an
+ambiguous-gap conflict here means resolving it up front with `--use-event <ID>`
+rather than hitting it partway through a real import, which aborts the whole
+batch and rolls back everything already added in that call.
 
-`--dry-run` only softens the outcome for gaps within the tighter
-`event_duplicate_tolerance` band. A gap in the wider band still raises.
+A gap in the ambiguous band raises during `--dry-run` just as it does on a real
+import.
 
 ## Automatic snapshots
 

--- a/src/aimbat/_cli/data.py
+++ b/src/aimbat/_cli/data.py
@@ -27,19 +27,21 @@ records are reused rather than duplicated.
 
 Near-duplicate events (two files whose origin times differ by only a
 sliver, most often from precision loss upstream such as SAC's `o`-header
-32-bit float, rather than genuinely distinct events) are flagged rather
-than silently merged. Resolving a flagged conflict is always first-wins:
-`--use-event <uuid>` links the new data to the pre-existing event's stored
-time and location exactly as they already are, it never merges, averages,
-or recomputes from the new file. Detection is controlled by
+32-bit float, rather than genuinely distinct events) are merged onto the
+pre-existing event rather than turned into a second one. Merging is always
+first-wins: the new data links to the pre-existing event's stored time and
+location exactly as they already are, never merging, averaging, or
+recomputing from the new file. Detection is controlled by
 `event_duplicate_tolerance` (below this, a gap is assumed to be ordinary
-precision noise), `event_duplicate_raise_tolerance` (above
-`event_duplicate_tolerance` but below this, a gap is treated as a likely
-data problem and always raises, even during `--dry-run`), and
-`event_duplicate_strict` (skips both checks entirely; with it set, events
-are only ever merged on an exact origin-time match, which is itself only
-accurate to the microsecond AIMBAT stores timestamps at, so any gap of a
-microsecond or more silently creates a second event).
+precision noise and the existing event is reused with a warning),
+`event_duplicate_raise_tolerance` (above `event_duplicate_tolerance` but
+below this, a gap is treated as a likely data problem and always raises,
+even during `--dry-run`; resolve it with `--use-event <uuid>` to link to
+the pre-existing event explicitly), and `event_duplicate_strict` (skips
+both checks entirely; with it set, events are only ever merged on an exact
+origin-time match, which is itself only accurate to the microsecond AIMBAT
+stores timestamps at, so any gap of a microsecond or more silently creates
+a second event).
 
 `data add` automatically creates a snapshot for each event that received new
 seismogram data, so there is no need to run `snapshot create` right after

--- a/src/aimbat/_config.py
+++ b/src/aimbat/_config.py
@@ -63,55 +63,41 @@ class Settings(BaseSettings):
     event_duplicate_raise_tolerance: PydanticPositiveTimedelta = Field(
         default=Timedelta(seconds=2),
         description=(
-            "Upper bound of the 'ambiguous gap' band: if a new event's origin "
-            "time is further than `event_duplicate_tolerance` but closer than "
-            "this value to an existing event's time, adding it raises an "
-            "error unconditionally (even during `--dry-run`), since a gap this "
-            "size is too large to be ordinary timestamp precision noise but "
-            "too small to confidently be two unrelated events. It usually "
-            "signals a timing problem in the source data that needs "
-            "investigating before import. Ignored entirely when "
-            "`event_duplicate_strict` is True. This check compares origin "
-            "times only, not location: two genuinely distinct, "
-            "geographically unrelated events whose times happen to land "
-            "within this tolerance of each other would still be flagged."
+            "Upper bound of the 'ambiguous gap' band. A new event whose "
+            "origin time is further than `event_duplicate_tolerance` but "
+            "closer than this to an existing event's time raises an error "
+            "unconditionally (even during `--dry-run`): the gap is too large "
+            "for timestamp precision noise, too small to be confidently "
+            "unrelated events. Compares origin times only, not location. "
+            "Ignored when `event_duplicate_strict` is True."
         ),
     )
 
     event_duplicate_strict: bool = Field(
         default=False,
         description=(
-            "If True, skip near-duplicate event detection entirely: both "
+            "If True, skip near-duplicate detection entirely: "
             "`event_duplicate_tolerance` and `event_duplicate_raise_tolerance` "
-            "are ignored, and events are only ever merged on an exact origin "
-            "time match. Origin times are stored with microsecond precision, "
-            "so this exact match is itself only accurate to the microsecond: "
-            "two times less than a microsecond apart are always treated as "
-            "the same event, while any gap of a microsecond or more, however "
-            "small, creates a fully independent event with no warning at "
-            "all. Use only when the source data are trusted to already be "
-            "free of timing problems at that precision (e.g. a catalogue "
-            "known to contain legitimately close, but genuinely distinct, "
-            "events such as an aftershock swarm)."
+            "are both ignored and events merge only on an exact origin-time "
+            "match (itself only microsecond-accurate, so any larger gap "
+            "silently creates a separate event). Use only for source data "
+            "trusted to be free of timing problems at that precision, e.g. a "
+            "catalogue of genuinely close but distinct events such as an "
+            "aftershock swarm."
         ),
     )
 
     event_duplicate_tolerance: PydanticPositiveTimedelta = Field(
         default=Timedelta(seconds=0.1),
         description=(
-            "Maximum time difference for a new event's origin time to be "
-            "treated as a possible duplicate of an existing one when no exact "
-            "match is found. Real-world origin times are rarely reported to "
-            "better than sub-second precision, and a gap in that range "
-            "usually reflects precision loss upstream (e.g. SAC's 32-bit "
-            "float `o` header) rather than two genuinely distinct events. "
-            "This is meant to catch that precision noise only. Outside "
-            "`--dry-run`, a detected near-duplicate within this tolerance "
-            "raises an error; during `--dry-run` it is reported as a warning "
-            "instead. A larger gap, up to `event_duplicate_raise_tolerance`, "
-            "is handled separately (see that field) rather than being "
-            "treated as ordinary noise. Ignored entirely when "
-            "`event_duplicate_strict` is True."
+            "Maximum origin-time difference for a new event to be treated as "
+            "a duplicate of an existing one when there is no exact match. A "
+            "gap this small usually reflects upstream precision loss (e.g. "
+            "SAC's 32-bit float `o` header) rather than a distinct event, so "
+            "the existing event is reused with a warning, exactly as an exact "
+            "match is (its stored time and location are unchanged). Larger "
+            "gaps are handled by `event_duplicate_raise_tolerance`. Ignored "
+            "when `event_duplicate_strict` is True."
         ),
     )
 

--- a/src/aimbat/core/_data.py
+++ b/src/aimbat/core/_data.py
@@ -81,22 +81,39 @@ def _format_gap_prefix(
     )
 
 
-def _format_duplicate_event_message(
+def _format_reused_near_duplicate_message(
     datasource: os.PathLike[str] | str,
     new_event: AimbatEvent,
     existing_event: AimbatEvent,
     gap: Timedelta,
     tolerance: Timedelta,
 ) -> str:
-    """Build the noise-band near-duplicate-event message."""
+    """Build the noise-band near-duplicate-event reuse message."""
     prefix = _format_gap_prefix(datasource, new_event, existing_event, gap)
     return (
-        f"Possible duplicate event: {prefix}, within the configured "
+        f"Near-duplicate event: {prefix}, within the configured "
         f"duplicate-detection tolerance ({fmt_timedelta(tolerance)}) but "
-        f"not an exact match. If these are the same event, re-run with "
-        f"'--use-event {existing_event.id}', or import an authoritative "
-        f"event record first using the 'json_event' data type."
+        f"not an exact match. Reusing the existing event; its stored time "
+        f"and location are kept unchanged. Set 'event_duplicate_strict' to "
+        f"treat close origin times as genuinely distinct events instead."
     )
+
+
+def _warn_on_event_location_mismatch(
+    datasource: os.PathLike[str] | str,
+    new_event: AimbatEvent,
+    existing_event: AimbatEvent,
+) -> None:
+    """Warn if the reused event's location metadata differs from the source's."""
+    if (
+        new_event.latitude != existing_event.latitude
+        or new_event.longitude != existing_event.longitude
+        or new_event.depth != existing_event.depth
+    ):
+        logger.warning(
+            f"Event at {existing_event.time} matched by time but has different "
+            f"location metadata in {datasource}. The existing record will be used."
+        )
 
 
 def _format_ambiguous_gap_message(
@@ -133,22 +150,23 @@ def _create_event(
     time is a near-duplicate of a known event's time, per
     `settings.event_duplicate_tolerance` / `event_duplicate_raise_tolerance`
     / `event_duplicate_strict` (see the `data add` module docstring for the
-    three-tier model). `known_event_ids` is updated in place with the ID of
-    any newly created event, so later data sources in the same batch are
-    checked against events created earlier in that batch too.
+    three-tier model). Within `event_duplicate_tolerance` the existing event
+    is reused (with a warning), exactly as an exact-time match is.
+    `known_event_ids` is updated in place with the ID of any newly created
+    event, so later data sources in the same batch are checked against
+    events created earlier in that batch too.
 
     Raises:
-        ValueError: If a real add (`dry_run=False`) finds a near-duplicate
-            within `event_duplicate_tolerance`, or if any near-duplicate
-            (regardless of `dry_run`) falls in the wider "ambiguous gap"
-            band up to `event_duplicate_raise_tolerance`.
+        ValueError: If a near-duplicate (regardless of `dry_run`) falls in
+            the wider "ambiguous gap" band between
+            `event_duplicate_tolerance` and
+            `event_duplicate_raise_tolerance`.
     """
 
     new_aimbat_event = create_event(datasource, datatype)
 
     statement = select(AimbatEvent).where(AimbatEvent.time == new_aimbat_event.time)
     aimbat_event = session.exec(statement).one_or_none()
-    duplicate_warning: str | None = None
 
     if aimbat_event is None:
         if not settings.event_duplicate_strict:
@@ -173,24 +191,24 @@ def _create_event(
                 # "closer than this value" description in _config.py).
                 if gap < raise_tolerance:
                     if gap <= tolerance:
-                        message = _format_duplicate_event_message(
+                        message = _format_reused_near_duplicate_message(
                             datasource, new_aimbat_event, closest, gap, tolerance
                         )
-                        if dry_run:
-                            duplicate_warning = message
-                        else:
-                            raise ValueError(message)
-                    else:
-                        raise ValueError(
-                            _format_ambiguous_gap_message(
-                                datasource,
-                                new_aimbat_event,
-                                closest,
-                                gap,
-                                tolerance,
-                                raise_tolerance,
-                            )
+                        logger.warning(message)
+                        _warn_on_event_location_mismatch(
+                            datasource, new_aimbat_event, closest
                         )
+                        return closest, message if dry_run else None
+                    raise ValueError(
+                        _format_ambiguous_gap_message(
+                            datasource,
+                            new_aimbat_event,
+                            closest,
+                            gap,
+                            tolerance,
+                            raise_tolerance,
+                        )
+                    )
         aimbat_event = new_aimbat_event
         logger.debug(f"Adding event {aimbat_event.time} to project.")
         session.add(aimbat_event)
@@ -199,17 +217,9 @@ def _create_event(
         logger.debug(
             f"Using existing event {aimbat_event.time} instead of adding new one."
         )
-        if (
-            new_aimbat_event.latitude != aimbat_event.latitude
-            or new_aimbat_event.longitude != aimbat_event.longitude
-            or new_aimbat_event.depth != aimbat_event.depth
-        ):
-            logger.warning(
-                f"Event at {aimbat_event.time} matched by time but has different "
-                f"location metadata in {datasource}. The existing record will be used."
-            )
+        _warn_on_event_location_mismatch(datasource, new_aimbat_event, aimbat_event)
 
-    return aimbat_event, duplicate_warning
+    return aimbat_event, None
 
 
 def _create_seismogram(
@@ -261,8 +271,9 @@ def _process_datasource(
         event_id: UUID of an existing event to link to instead of extracting
             one from `datasource`.
         dry_run: If True, a near-duplicate event within
-            `settings.event_duplicate_tolerance` is collected as a warning
-            instead of raising.
+            `settings.event_duplicate_tolerance` is surfaced as a preview
+            warning message (in addition to the log warning a real add
+            also emits).
         known_event_ids: IDs of events eligible for near-duplicate matching;
             updated in place as new events are created, so later data sources
             in the same batch are checked against earlier ones too.
@@ -270,18 +281,18 @@ def _process_datasource(
     Returns:
         A 2-tuple of the created or reused `AimbatDataSource` (or `None` if
         `datatype` does not support seismogram creation) and a near-duplicate
-        warning message (or `None` if no near-duplicate was found, or if the
-        one found was outside `settings.event_duplicate_tolerance`).
+        warning message for a dry run (or `None` if not a dry run, no
+        near-duplicate was found, or the one found was outside
+        `settings.event_duplicate_tolerance`).
 
     Raises:
         ValueError: If `event_id` is given but no matching event exists, if
             `datatype` does not support the station or event creation
-            required to link a seismogram, if a real add (`dry_run=False`)
-            finds a near-duplicate event within
-            `settings.event_duplicate_tolerance`, or if a near-duplicate
-            event falls in the wider "ambiguous gap" band up to
-            `settings.event_duplicate_raise_tolerance` (the latter is
-            raised regardless of `dry_run`).
+            required to link a seismogram, or if a near-duplicate event
+            falls in the "ambiguous gap" band between
+            `settings.event_duplicate_tolerance` and
+            `settings.event_duplicate_raise_tolerance` (raised regardless of
+            `dry_run`).
     """
 
     duplicate_warning: str | None = None
@@ -380,12 +391,12 @@ def add_data_to_project(
     from the data source and link to a pre-existing record instead.
 
     A new event whose origin time nearly, but not exactly, matches a
-    pre-existing event's time is flagged as a possible near-duplicate (see
+    pre-existing event's time is handled per
     `settings.event_duplicate_tolerance`, `event_duplicate_raise_tolerance`,
-    and `event_duplicate_strict`). Within the tighter tolerance, a real add
-    raises `ValueError` while a dry run collects a warning instead; within
-    the wider "ambiguous gap" band, a `ValueError` is raised unconditionally,
-    even during a dry run.
+    and `event_duplicate_strict`. Within the tighter tolerance the existing
+    event is reused, with a log warning (a dry run additionally returns the
+    message in `duplicate_warnings`). Within the wider "ambiguous gap" band,
+    a `ValueError` is raised unconditionally, even during a dry run.
 
     Args:
         session: The SQLModel database session.
@@ -408,12 +419,13 @@ def add_data_to_project(
         seismogram IDs that already existed in the database *before* this
         call, so callers can tell which entries in `added_datasources` are
         newly created versus reused by comparing IDs against these sets.
-        `duplicate_warnings` lists near-duplicate-event messages collected
-        during a dry run (always empty on a real-add call, since a real-add
-        near-duplicate raises instead of being collected).
+        `duplicate_warnings` lists near-duplicate-event reuse messages
+        collected during a dry run (always empty on a real-add call, which
+        logs the same message as a warning instead).
 
     Raises:
-        ValueError: If a near-duplicate event is found (see above).
+        ValueError: If a near-duplicate event falls in the "ambiguous gap"
+            band (see above).
     """
 
     logger.info(f"Adding {len(data_sources)} {data_type} data sources to project.")

--- a/tests/integration/core/test_data.py
+++ b/tests/integration/core/test_data.py
@@ -394,10 +394,10 @@ class TestNearDuplicateEventDetection:
 
     # -- Noise band (within event_duplicate_tolerance) --------------------
 
-    def test_near_duplicate_event_raises_on_real_add(
+    def test_near_duplicate_event_reused_on_real_add(
         self, sac_file_good: Path, patched_session: Session, tmp_path: Path
     ) -> None:
-        """A real add raises when within event_duplicate_tolerance of an existing event.
+        """A real add reuses the existing event within event_duplicate_tolerance.
 
         Args:
             sac_file_good: Path to a valid SAC file.
@@ -405,17 +405,22 @@ class TestNearDuplicateEventDetection:
             tmp_path: Temporary directory for the shifted copy.
         """
         add_data_to_project(patched_session, [sac_file_good], data_type=DataType.SAC)
+        existing = patched_session.exec(select(AimbatEvent)).one()
         near_dup = self._shifted_copy(sac_file_good, tmp_path, 0.02, "near_dup.sac")
 
-        with pytest.raises(ValueError):
-            add_data_to_project(patched_session, [near_dup], data_type=DataType.SAC)
+        added_datasources, _, _, _, duplicate_warnings = add_data_to_project(
+            patched_session, [near_dup], data_type=DataType.SAC
+        )
 
         assert len(patched_session.exec(select(AimbatEvent)).all()) == 1
+        assert added_datasources[0].seismogram.event_id == existing.id
+        # A real add logs the reuse warning rather than returning it.
+        assert duplicate_warnings == []
 
-    def test_near_duplicate_event_warns_on_dry_run(
+    def test_near_duplicate_event_previews_reuse_on_dry_run(
         self, sac_file_good: Path, patched_session: Session, tmp_path: Path
     ) -> None:
-        """A dry run collects a warning instead of raising within the noise band.
+        """A dry run previews the near-duplicate as a reused, pre-existing event.
 
         Args:
             sac_file_good: Path to a valid SAC file.
@@ -423,6 +428,7 @@ class TestNearDuplicateEventDetection:
             tmp_path: Temporary directory for the shifted copy.
         """
         add_data_to_project(patched_session, [sac_file_good], data_type=DataType.SAC)
+        existing = patched_session.exec(select(AimbatEvent)).one()
         near_dup = self._shifted_copy(sac_file_good, tmp_path, 0.02, "near_dup.sac")
 
         (
@@ -437,11 +443,12 @@ class TestNearDuplicateEventDetection:
 
         assert len(duplicate_warnings) == 1
         assert str(near_dup) in duplicate_warnings[0]
+        assert str(existing.id) in duplicate_warnings[0]
 
-        # First-wins preview: the near-duplicate is still listed as a newly
-        # added event in the same call that produces the warning.
+        # The near-duplicate previews as a reused (pre-existing) event.
         assert len(added_datasources) == 1
-        assert added_datasources[0].seismogram.event_id not in existing_event_ids
+        assert added_datasources[0].seismogram.event_id == existing.id
+        assert added_datasources[0].seismogram.event_id in existing_event_ids
 
     # -- Ambiguous-gap band (between the two tolerances) -------------------
 
@@ -504,10 +511,10 @@ class TestNearDuplicateEventDetection:
 
         assert len(patched_session.exec(select(AimbatEvent)).all()) == 2
 
-    def test_same_batch_near_duplicates_are_flagged(
+    def test_same_batch_near_duplicates_are_merged(
         self, sac_file_good: Path, patched_session: Session, tmp_path: Path
     ) -> None:
-        """Near-duplicates within the same batch are compared against each other too.
+        """Near-duplicates within the same batch merge onto the first file's event.
 
         Args:
             sac_file_good: Path to a valid SAC file.
@@ -516,14 +523,13 @@ class TestNearDuplicateEventDetection:
         """
         near_dup = self._shifted_copy(sac_file_good, tmp_path, 0.02, "near_dup.sac")
 
-        with pytest.raises(ValueError):
-            add_data_to_project(
-                patched_session, [sac_file_good, near_dup], data_type=DataType.SAC
-            )
+        added_datasources, _, _, _, _ = add_data_to_project(
+            patched_session, [sac_file_good, near_dup], data_type=DataType.SAC
+        )
 
-        # The whole batch shares one nested transaction, so the raise on the
-        # second file rolls back the first file's event too.
-        assert len(patched_session.exec(select(AimbatEvent)).all()) == 0
+        events = patched_session.exec(select(AimbatEvent)).all()
+        assert len(events) == 1
+        assert {ds.seismogram.event_id for ds in added_datasources} == {events[0].id}
 
     def test_gap_exactly_at_raise_tolerance_is_independent(
         self, event_json: Path, patched_session: Session
@@ -552,7 +558,7 @@ class TestNearDuplicateEventDetection:
     def test_multiple_near_duplicates_picks_closest(
         self, sac_file_good: Path, patched_session: Session
     ) -> None:
-        """The closest pre-existing near-duplicate is identified, not the first found.
+        """The closest pre-existing near-duplicate is the one reused.
 
         Args:
             sac_file_good: Path to a valid SAC file.
@@ -562,13 +568,13 @@ class TestNearDuplicateEventDetection:
         far = self._seed_event(patched_session, new_time - Timedelta(seconds=0.09))
         close = self._seed_event(patched_session, new_time + Timedelta(seconds=0.04))
 
-        with pytest.raises(ValueError) as excinfo:
-            add_data_to_project(
-                patched_session, [sac_file_good], data_type=DataType.SAC
-            )
+        added_datasources, _, _, _, _ = add_data_to_project(
+            patched_session, [sac_file_good], data_type=DataType.SAC
+        )
 
-        assert str(close.id) in str(excinfo.value)
-        assert str(far.id) not in str(excinfo.value)
+        assert len(patched_session.exec(select(AimbatEvent)).all()) == 2
+        assert added_datasources[0].seismogram.event_id == close.id
+        assert added_datasources[0].seismogram.event_id != far.id
 
     def test_closest_match_determines_band(
         self, sac_file_good: Path, patched_session: Session
@@ -585,13 +591,13 @@ class TestNearDuplicateEventDetection:
         )
         self._seed_event(patched_session, new_time - Timedelta(seconds=1))
 
-        with pytest.raises(ValueError) as excinfo:
-            add_data_to_project(
-                patched_session, [sac_file_good], data_type=DataType.SAC
-            )
+        # Closest match is in the noise band, so the event is reused rather
+        # than raising, despite an ambiguous-gap match also being in range.
+        added_datasources, _, _, _, _ = add_data_to_project(
+            patched_session, [sac_file_good], data_type=DataType.SAC
+        )
 
-        assert "--use-event" in str(excinfo.value)
-        assert str(noise_band_event.id) in str(excinfo.value)
+        assert added_datasources[0].seismogram.event_id == noise_band_event.id
 
     # -- strict mode ---------------------------------------------------
 


### PR DESCRIPTION
A near-duplicate origin time within event_duplicate_tolerance now reuses the existing event (with a warning), the same as an exact origin-time match, instead of raising on a real add. The ambiguous-gap band still raises unconditionally.

<!-- readthedocs-preview aimbat start -->
----
📚 Documentation preview 📚: https://aimbat--262.org.readthedocs.build/en/262/

<!-- readthedocs-preview aimbat end -->