### PR TITLE
test: parallelise the non-slow test suite with pytest-xdist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ pysmo.aimbat.egg-info/
 coverage.xml
 old
 .coverage
+.coverage.*
 sample-data
 aimbat.db
 .check-migrations.db

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ else
   PYTHON_VERSION := python3
 endif
 
+# Number of pytest-xdist workers for the non-slow test pass. Override on a
+# constrained machine, e.g. `make tests PYTEST_WORKERS=4`.
+PYTEST_WORKERS ?= auto
+
 help: ## List all commands.
 	@echo -e "\nThis makefile executes mostly uv commands. To view all uv commands available run 'uv help'."
 	@echo -e "\n\033[1mAVAILABLE COMMANDS\033[0m"
@@ -73,10 +77,14 @@ test-figs: check-uv ## Generate baseline figures for testing (then manually move
 	uv run py.test --mpl-generate-path=baseline
 
 tests: check-uv mypy ## Run tests with pytest (excludes slow functional tests).
-	uv run pytest --cov --cov-report=term-missing --cov-report=html --mpl -m "not slow"
+	uv run pytest -n $(PYTEST_WORKERS) --dist worksteal --cov --cov-report=term-missing --cov-report=html --mpl -m "not slow"
 
+# The slow functional tests shell out to `uv run`, which is not safe to invoke
+# concurrently against the shared project .venv - they run serially after the
+# parallel non-slow pass, appending to the same coverage data.
 tests-full: check-uv mypy ## Run all tests including slow functional tests.
-	uv run pytest --cov --cov-report=term-missing --cov-report=html --mpl
+	uv run pytest -n $(PYTEST_WORKERS) --dist worksteal --cov --mpl -m "not slow"
+	uv run pytest --cov --cov-append --cov-report=term-missing --cov-report=html --mpl -m "slow"
 
 upgrade: check-uv ## Upgrade dependencies to their latest versions.
 	uv sync --upgrade

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,10 +46,10 @@ aimbat-tui = "aimbat._cli.tui:app"
 test = [
   "pytest>=8.4.2",
   "pytest-cov>=7.0.0",
-  "pytest-dependency>=0.6.0",
   "pytest-mpl>=0.17.0",
   "pytest-mypy>=1.0.1",
   "pytest-sugar>=1.1.1",
+  "pytest-xdist>=3.8.0",
   "ruff>=0.13.0",
   "testkit",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,8 +30,18 @@ from aimbat.logger import configure_logging
 # Constants
 # ---------------------------------------------------------------------------
 
-_AIMBAT_LOGFILE = "aimbat_test.log"
 _AIMBAT_LOG_LEVEL: Literal["DEBUG"] = "DEBUG"
+
+
+def _worker_logfile() -> str:
+    """Log file name for the current test session, unique per xdist worker.
+
+    Under ``pytest-xdist`` every worker runs in its own process but shares the
+    working directory, so a fixed name would have all workers appending to one
+    file. ``PYTEST_XDIST_WORKER`` is unset on a non-parallel run (``"master"``).
+    """
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "master")
+    return f"aimbat_test_{worker}.log"
 
 
 # ---------------------------------------------------------------------------
@@ -49,7 +59,7 @@ def patch_debug_setting(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None
     Yields:
         None
     """
-    monkeypatch.setattr(aimbat.settings, "logfile", _AIMBAT_LOGFILE)
+    monkeypatch.setattr(aimbat.settings, "logfile", _worker_logfile())
     monkeypatch.setattr(aimbat.settings, "log_level", _AIMBAT_LOG_LEVEL)
     configure_logging()
 
@@ -402,7 +412,7 @@ def aimbat_subprocess(
     def _run(args: Sequence[str]) -> subprocess.CompletedProcess[str]:
         env = os.environ.copy()
         env["AIMBAT_DB_URL"] = f"sqlite+pysqlite:///{db_path}"
-        env["AIMBAT_LOGFILE"] = _AIMBAT_LOGFILE
+        env["AIMBAT_LOGFILE"] = _worker_logfile()
         env["AIMBAT_LOG_LEVEL"] = _AIMBAT_LOG_LEVEL
         env["COLUMNS"] = "1000"
         return subprocess.run(

--- a/tests/functional/test_shell.py
+++ b/tests/functional/test_shell.py
@@ -14,7 +14,11 @@ import pytest
 from aimbat._cli.shell import _build_completion_dict, _extract_event_flag
 from aimbat.app import app as aimbat_app
 
-_AIMBAT_LOGFILE = "aimbat_test.log"
+
+def _worker_logfile() -> str:
+    """Log file name unique per xdist worker (``"master"`` off a non-parallel run)."""
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "master")
+    return f"aimbat_test_{worker}.log"
 
 
 # ---------------------------------------------------------------------------
@@ -38,7 +42,7 @@ def shell_subprocess(
     def _run(stdin: str) -> subprocess.CompletedProcess[str]:
         env = os.environ.copy()
         env["AIMBAT_DB_URL"] = f"sqlite+pysqlite:///{db_path}"
-        env["AIMBAT_LOGFILE"] = _AIMBAT_LOGFILE
+        env["AIMBAT_LOGFILE"] = _worker_logfile()
         env["COLUMNS"] = "1000"
         return subprocess.run(
             ["uv", "run", "aimbat", "shell"],

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-env_list = lint, py{312,313,314}, report
+env_list = lint, py{313,314}, report
 isolated_build = true
 
 [gh-actions]
 python =
-  3.12: py312
   3.13: py313
   3.14: py314, lint
 
@@ -13,14 +12,19 @@ description = run the tests with pytest
 passenv =
   UV_*
 setenv =
-  py{312,313,314}: COVERAGE_FILE = {env:COVERAGE_FILE:.coverage.{envname}}
+  py{313,314}: COVERAGE_FILE = {env:COVERAGE_FILE:.coverage.{envname}}
 depends =
-  report: py312, py313, py314
+  report: py313, py314
 allowlist_externals = uv
 commands_pre =
   uv sync --active --inexact --python python --no-group docs
+# The non-slow tests run in parallel; the slow functional tests run serially
+# afterwards because they shell out to `uv run`, which is not safe to invoke
+# concurrently against the shared project .venv. mypy runs as its own pass.
 commands =
-  py.test --mpl --mypy --cov --cov-append --cov-report=term-missing  --junitxml=junit.xml
+  py.test -n auto --dist worksteal --mpl --cov -m "not slow"
+  py.test --mpl --cov --cov-append --cov-report=term-missing -m "slow"
+  py.test --mypy -m mypy src tests
 
 [testenv:report]
 description = create test report

--- a/uv.lock
+++ b/uv.lock
@@ -47,10 +47,10 @@ docs = [
 test = [
     { name = "pytest" },
     { name = "pytest-cov" },
-    { name = "pytest-dependency" },
     { name = "pytest-mpl" },
     { name = "pytest-mypy" },
     { name = "pytest-sugar" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "testkit" },
 ]
@@ -90,10 +90,10 @@ docs = [
 test = [
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
-    { name = "pytest-dependency", specifier = ">=0.6.0" },
     { name = "pytest-mpl", specifier = ">=0.17.0" },
     { name = "pytest-mypy", specifier = ">=1.0.1" },
     { name = "pytest-sugar", specifier = ">=1.1.1" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.13.0" },
     { name = "testkit", git = "https://github.com/pysmo/testkit?tag=v0.2.0" },
 ]
@@ -546,6 +546,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -1903,16 +1912,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pytest-dependency"
-version = "0.6.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pytest" },
-    { name = "setuptools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/ea/84509533e0f6477960b8a9179d240d93c909c6543e4dd8209932026d7815/pytest_dependency-0.6.1.tar.gz", hash = "sha256:246c24d2a5fc743a942cec4408853640e56a05ba58d46e5b213a1d4b738a2464", size = 20837, upload-time = "2026-02-15T18:08:43.927Z" }
-
-[[package]]
 name = "pytest-mpl"
 version = "0.19.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1953,6 +1952,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0b/4e/60fed105549297ba1a700e1ea7b828044842ea27d72c898990510b79b0e2/pytest-sugar-1.1.1.tar.gz", hash = "sha256:73b8b65163ebf10f9f671efab9eed3d56f20d2ca68bda83fa64740a92c08f65d", size = 16533, upload-time = "2025-08-23T12:19:35.737Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/d5/81d38a91c1fdafb6711f053f5a9b92ff788013b19821257c2c38c1e132df/pytest_sugar-1.1.1-py3-none-any.whl", hash = "sha256:2f8319b907548d5b9d03a171515c1d43d2e38e32bd8182a1781eb20b43344cc8", size = 11440, upload-time = "2025-08-23T12:19:34.894Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]
@@ -2114,15 +2126,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/2e/f97a666d362fee68b18f41c9c30ed502ca5c98b549749bfcb52a8b74d1eb/scipy-1.18.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:11c423f1049c5755ad4409af52a9ada1cff96fe9b50795d4af3619f292901239", size = 37525424, upload-time = "2026-08-21T23:26:56.751Z" },
     { url = "https://files.pythonhosted.org/packages/ca/d5/a9e765a84654ebba8479a1fd1b059ced1af72b168a3b2a3a46540ea38d20/scipy-1.18.1-cp314-cp314t-win_amd64.whl", hash = "sha256:c24acac1e18912761c4700239bbc1fd32f615af690f1584d49b35859be51324d", size = 37416961, upload-time = "2026-08-21T23:27:01.546Z" },
     { url = "https://files.pythonhosted.org/packages/ee/16/e79e0d1c63ef698879d85439d37e9fb434e3b804e506a6991038d086ebd9/scipy-1.18.1-cp314-cp314t-win_arm64.whl", hash = "sha256:9f2897bf7737392ad0d5213ea7b6add72a4edf5679b3153106aeb88b6507b3b9", size = 25331848, upload-time = "2026-08-21T23:27:05.884Z" },
-]
-
-[[package]]
-name = "setuptools"
-version = "84.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6d/44/f5da03a8ef95d369145c5bb53050e7877c9f3d312e128605fd9504829143/setuptools-84.0.0.tar.gz", hash = "sha256:f4695c21257f0d9b537ec2692c941d02ee143b7cc1276941349a546573b2ef73", size = 1168449, upload-time = "2026-08-08T18:27:58.365Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/9c/c510029fc6ef33a6275cd2c5d3cecd6613dfd6aa401d57c54f1c18852ccf/setuptools-84.0.0-py3-none-any.whl", hash = "sha256:51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670", size = 818216, upload-time = "2026-08-08T18:27:56.719Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`make tests` and `tox` now run the non-slow tests under `-n auto`. The slow functional tests stay in a serial pass — they shell out to `uv run`, which is not safe to invoke concurrently against the shared project .venv.

- add pytest-xdist, drop the unused pytest-dependency
- per-worker log files keyed on PYTEST_XDIST_WORKER so workers don't all append to one aimbat_test.log
- PYTEST_WORKERS override in the Makefile for constrained machines
- tox: split into parallel non-slow / serial slow / mypy passes, and drop py312 from the env list (requires-python is >=3.13)

<!-- readthedocs-preview aimbat start -->
----
📚 Documentation preview 📚: https://aimbat--263.org.readthedocs.build/en/263/

<!-- readthedocs-preview aimbat end -->