### PR TITLE
test: write per-worker log files to gitignored tests/.logs/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ junit.xml
 .envrc
 aimbat.log
 .env
-aimbat_test*.log
+tests/.logs/
 scratch/
 aimbat.db-shm
 aimbat.db-wal

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,15 +33,35 @@ from aimbat.logger import configure_logging
 _AIMBAT_LOG_LEVEL: Literal["DEBUG"] = "DEBUG"
 
 
+_LOG_DIR = Path(__file__).parent / ".logs"
+
+
 def _worker_logfile() -> str:
-    """Log file name for the current test session, unique per xdist worker.
+    """Log file path for the current test session, unique per xdist worker.
 
     Under ``pytest-xdist`` every worker runs in its own process but shares the
     working directory, so a fixed name would have all workers appending to one
     file. ``PYTEST_XDIST_WORKER`` is unset on a non-parallel run (``"master"``).
+
+    Logs are written to the gitignored ``tests/.logs/`` directory to keep them
+    out of the project root.
     """
     worker = os.environ.get("PYTEST_XDIST_WORKER", "master")
-    return f"aimbat_test_{worker}.log"
+    _LOG_DIR.mkdir(exist_ok=True)
+    return str(_LOG_DIR / f"aimbat_test_{worker}.log")
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Wipe the test log directory at the start of each session.
+
+    Runs only on the xdist controller (``workerinput`` is absent), before any
+    worker boots, so ``tests/.logs/`` never accumulates more than one session's
+    worth of logs.
+    """
+    if hasattr(config, "workerinput"):
+        return
+    if _LOG_DIR.is_dir():
+        shutil.rmtree(_LOG_DIR)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/functional/test_shell.py
+++ b/tests/functional/test_shell.py
@@ -14,11 +14,18 @@ import pytest
 from aimbat._cli.shell import _build_completion_dict, _extract_event_flag
 from aimbat.app import app as aimbat_app
 
+_LOG_DIR = Path(__file__).parents[1] / ".logs"
+
 
 def _worker_logfile() -> str:
-    """Log file name unique per xdist worker (``"master"`` off a non-parallel run)."""
+    """Log file path unique per xdist worker (``"master"`` off a non-parallel run).
+
+    Written to the gitignored ``tests/.logs/`` directory to keep logs out of the
+    project root.
+    """
     worker = os.environ.get("PYTEST_XDIST_WORKER", "master")
-    return f"aimbat_test_{worker}.log"
+    _LOG_DIR.mkdir(exist_ok=True)
+    return str(_LOG_DIR / f"aimbat_test_{worker}.log")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The aimbat_test_*.log files were written to the project root, one per xdist worker. Move them into tests/.logs/ (gitignored) and wipe that directory at the start of each session so it never accumulates more than one run's worth of logs.

<!-- readthedocs-preview aimbat start -->
----
📚 Documentation preview 📚: https://aimbat--264.org.readthedocs.build/en/264/

<!-- readthedocs-preview aimbat end -->