### PR TITLE
feat(io): defer waveform writes until session commit

### DIFF
--- a/docs/usage/api-basics.md
+++ b/docs/usage/api-basics.md
@@ -19,8 +19,8 @@ The API has three primary parts:
     records come from [`select`][sqlalchemy.sql.expression.select] queries.
 3. **Core functions.** High-level operations on those models
     ([`aimbat.core`][]): event selection, parameter changes, ICCS and MCCC
-    runs, snapshots. The CLI, shell, and TUI call the same functions, which
-    commit internally.
+    runs, snapshots. The CLI, shell, and TUI call the same functions, and the
+    mutating ones commit internally.
 
 ## Starting a session
 
@@ -144,3 +144,39 @@ Each commit is a disk write. Calling a core function that commits internally,
 such as [`set_seismogram_parameter`][aimbat.core.set_seismogram_parameter], once
 per seismogram in a loop costs one commit per iteration. For changes across many
 records, mutating them directly and committing once after the loop avoids that.
+
+## Working with seismogram data
+
+The waveform samples for a seismogram are not a database column. They live in
+the data source (the SAC or miniSEED file), and
+[`AimbatSeismogram.data`][aimbat.models.AimbatSeismogram] reads and writes
+them there.
+
+```python
+with Session(engine) as session:
+    seis = session.exec(select(AimbatSeismogram)).first()
+
+    samples = seis.data          # read-only NumPy array
+    seis.data = samples * 2.0    # staged, not yet on disk
+    session.commit()             # now written to the data source
+```
+
+Reading `data` returns a **read-only** array; `seis.data[0] = 1.0` raises.
+Assigning `data` **stages** the write in the session, like any other model
+change: it reaches the data source when the session commits and is discarded
+if the session rolls back. Reads through the same session see the staged
+value before the commit; other sessions see the old one until then.
+
+AIMBAT itself never writes waveform samples — every processing step writes
+parameters to the database. This matters only for custom scripts that replace
+a seismogram's waveform.
+
+!!! note "Embedding AIMBAT in a larger application"
+
+    Importing `aimbat.models` (or `aimbat.db`, or any AIMBAT code that
+    reads the project database) registers commit and rollback listeners on
+    SQLAlchemy's `Session` class for the whole process, so that a staged
+    `data` write is never silently lost. Every `Session` in the process,
+    including those of unrelated libraries, then runs a short check on each
+    commit and rollback; the work only happens for a session that actually
+    staged a waveform write.

--- a/src/aimbat/io/__init__.py
+++ b/src/aimbat/io/__init__.py
@@ -18,6 +18,7 @@ from .._utils import export_module_names
 
 _internal_names = set(dir())
 
+from . import _flush as _flush  # registers Session commit/rollback listeners
 from . import json as json
 from . import mseed as mseed
 from . import sac as sac

--- a/src/aimbat/io/_base.py
+++ b/src/aimbat/io/_base.py
@@ -16,6 +16,7 @@ from collections import OrderedDict
 from collections.abc import Callable
 from os import PathLike
 from typing import TYPE_CHECKING
+from weakref import WeakKeyDictionary
 
 import numpy as np
 import numpy.typing as npt
@@ -25,6 +26,8 @@ from aimbat.logger import logger
 from ._data import DataType
 
 if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
     from aimbat.models import (
         AimbatEvent,
         AimbatSeismogram,
@@ -47,6 +50,7 @@ __all__ = [
     "seismogram_creator",
     "seismogram_data_reader",
     "seismogram_data_writer",
+    "stage_seismogram_data",
     "station_creator",
     "supports_event_creation",
     "supports_seismogram_creation",
@@ -60,6 +64,15 @@ __all__ = [
 # entry only costs a re-read.
 _CACHE_MAX_ENTRIES = 1024
 _cache: OrderedDict[tuple[str, DataType], npt.NDArray[np.floating]] = OrderedDict()
+
+# Per-session staged waveform writes, keyed weakly by the owning `Session`.
+# `stage_seismogram_data` fills this; the listeners in `aimbat.io._flush`
+# flush a session's pages to disk on its commit and drop them on rollback.
+# Weak keys mean an abandoned session (never committed or rolled back) loses
+# its staged pages when it is garbage-collected.
+_pending: WeakKeyDictionary[
+    Session, dict[tuple[str, DataType], npt.NDArray[np.floating]]
+] = WeakKeyDictionary()
 
 # Per-capability registries, populated by data source modules (e.g. _sac)
 _station_creators: dict[DataType, Callable[[str | PathLike[str]], AimbatStation]] = {}
@@ -383,18 +396,23 @@ def create_seismogram(
 
 
 def read_seismogram_data(
-    datasource: str | PathLike[str], datatype: DataType
+    datasource: str | PathLike[str],
+    datatype: DataType,
+    session: Session | None = None,
 ) -> npt.NDArray[np.floating]:
     """Read seismogram waveform data from a data source.
 
     Results are cached in memory by `(datasource, datatype)` key. The returned
-    array is read-only; to write new data use `write_seismogram_data`. The
-    cache entry is invalidated when `write_seismogram_data` is called for the
-    same key.
+    array is read-only.
+
+    If `session` is given and has a staged write for this key (from
+    `stage_seismogram_data`), the staged value is returned instead of reading
+    the data source, so a session sees its own uncommitted waveform write.
 
     Args:
         datasource: Data source path or name.
         datatype: Data type of the source.
+        session: Session whose staged writes should be consulted first.
 
     Returns:
         Read-only seismogram waveform data as a NumPy array.
@@ -403,12 +421,17 @@ def read_seismogram_data(
         NotImplementedError: If `datatype` has no registered data reader.
     """
     logger.debug(f"Reading seismogram data from {datasource}.")
+    key = (str(datasource), datatype)
+    if session is not None:
+        staged = _pending.get(session)
+        if staged is not None and key in staged:
+            logger.debug(f"Retrieved staged seismogram data for {datasource}.")
+            return staged[key]
     reader = _seismogram_data_readers.get(datatype)
     if reader is None:
         raise NotImplementedError(
             f"{datatype} does not support reading seismogram data."
         )
-    key = (str(datasource), datatype)
     if key in _cache:
         logger.debug(f"Retrieved seismogram data from cache for {datasource}.")
         _cache.move_to_end(key)
@@ -428,7 +451,10 @@ def write_seismogram_data(
 ) -> None:
     """Write seismogram waveform data to a data source.
 
-    Invalidates the cache entry for `(datasource, datatype)` after writing.
+    Writes eagerly and invalidates the cache entry for `(datasource,
+    datatype)`. `AimbatSeismogram.data` assignment no longer calls this
+    directly - it stages the write via `stage_seismogram_data` and the flush
+    listener in `aimbat.io._flush` calls this on the owning session's commit.
 
     Args:
         datasource: Data source path or name.
@@ -448,6 +474,69 @@ def write_seismogram_data(
     _cache.pop((str(datasource), datatype), None)
 
 
+def stage_seismogram_data(
+    session: Session | None,
+    datasource: str | PathLike[str],
+    datatype: DataType,
+    data: npt.NDArray[np.floating],
+) -> None:
+    """Stage a waveform write to flush when `session` commits.
+
+    The write is validated immediately (a datatype with no registered writer
+    raises straight away), but the data source is not touched until `session`
+    commits. The staged value is discarded if `session` rolls back or is
+    abandoned, and is visible to reads made through the same session before
+    the commit.
+
+    A copy of `data` is taken at call time, so later mutation of the caller's
+    array does not change what is persisted. The `(datasource, datatype)` key
+    is also captured now: renaming the data source on the model before the
+    commit would flush to the old path. Staged pages are held in memory until
+    the commit with no eviction (unlike the read cache), so staging waveform
+    writes for a very large event holds every new array at once.
+
+    Staging is keyed by `(datasource, datatype)`, not by seismogram: staging
+    a second write for the same data source in one session before committing
+    replaces the first, and only the last survives the flush.
+
+    If `session` is `None` (a detached instance, attached to no session)
+    there is no transaction to bind to, so the write falls back to an eager
+    `write_seismogram_data` call.
+
+    Args:
+        session: The session that owns the seismogram, or `None`.
+        datasource: Data source path or name.
+        datatype: Data type of the source.
+        data: Seismogram waveform data to write.
+
+    Raises:
+        NotImplementedError: If `datatype` has no registered data writer.
+    """
+    if datatype not in _seismogram_data_writers:
+        raise NotImplementedError(
+            f"{datatype} does not support writing seismogram data."
+        )
+    if session is None:
+        msg = f"Waveform write for detached seismogram {datasource}: "
+        logger.warning(msg + "no session to bind to, writing eagerly.")
+        write_seismogram_data(datasource, datatype, data)
+        return
+    logger.debug(f"Staging seismogram data write to {datasource}.")
+    staged = np.array(data, copy=True)
+    staged.flags.writeable = False
+    session_pending = _pending.setdefault(session, {})
+    key = (str(datasource), datatype)
+    if key in session_pending:
+        logger.warning(
+            f"Replacing an earlier staged waveform write for {datasource}; "
+            + "only the latest is flushed on commit."
+        )
+    session_pending[key] = staged
+
+
 def clear_seismogram_data_cache() -> None:
-    """Drop every entry from the in-memory waveform cache."""
+    """Drop every entry from the in-memory waveform read cache.
+
+    Staged (uncommitted) writes in `_pending` are left intact.
+    """
     _cache.clear()

--- a/src/aimbat/io/_flush.py
+++ b/src/aimbat/io/_flush.py
@@ -1,0 +1,88 @@
+"""Session-scoped flushing of staged waveform writes.
+
+Assigning `AimbatSeismogram.data` stages the array in the per-session buffer
+in `aimbat.io._base` instead of writing it to the data source. The listeners
+here write a session's staged pages to their data sources just before it
+commits, and discard them when it rolls back. They are registered on the
+`Session` class, so they fire for every session in the process, but both are
+no-ops for a session that never staged a write: they only ever touch
+`_pending[session]` for the committing or rolling-back session, and one unit
+of work never flushes another's staged writes. Registering on the class
+(rather than a `sessionmaker` owned by `aimbat.db`) is deliberate - any
+session bound to the project database gets the deferred-write behaviour,
+including one opened by a downstream consumer, so `seis.data = ...` can never
+be silently dropped for want of the "right" session factory.
+
+Flushing happens in `before_commit`. The listener first calls
+`session.flush()` so that any ORM-level failure in the pending unit of work
+(a constraint violation, a failed validator, an `IntegrityError` on an
+unrelated row) is raised before a single byte is written to a data source.
+Only then are the staged pages written. A failed data-source write (disk
+full, permissions) aborts `session.commit()` from a recoverable state: the
+staged pages stay in `_pending`, so calling `session.commit()` again retries
+them, and `session.rollback()` discards them.
+
+The residual inconsistency window is narrow but real: a data-source write
+succeeds and then the database `COMMIT` itself fails (or the process crashes
+between the two). The file is left updated with the database unchanged, and
+there is no journal to replay. This is strictly smaller than the pre-deferral
+eager write, which mutated the file at assignment time - long before the
+commit - but it is not eliminated. `session.rollback()` after such a failure
+drops the staged pages; the already-written file is not reverted.
+
+`_discard_pending` is on `after_soft_rollback`, which fires for every
+rollback and receives the transaction that ended. `after_rollback` is
+deliberately not used: it also fires for a SAVEPOINT
+(`session.begin_nested()`) rollback, which must not drop pages staged on the
+enclosing transaction. `after_soft_rollback` reports `nested=True` for a
+SAVEPOINT rollback (ignored) and `nested=False` for a full rollback (pages
+dropped). An abandoned session - never committed or rolled back - drops its
+pages when it is garbage-collected (weak keys in `_pending`).
+
+Thread-safety: the TUI commits on its main thread while a background thread
+builds ICCS and reads staged values through the getter. Each thread uses its
+own `Session` (sessions are not thread-safe), so no two threads stage or
+flush the same `_pending` key, and every staged array is copied on stage and
+read-only on read. Reads of another thread's staged pages are best-effort.
+Concurrent staging from multiple threads is not supported and would need its
+own synchronisation.
+"""
+
+from sqlalchemy import event
+from sqlalchemy.orm import Session, SessionTransaction
+
+from aimbat.logger import logger
+
+from . import _base
+
+
+@event.listens_for(Session, "before_commit")
+def _flush_pending(session: Session) -> None:
+    """Write `session`'s staged waveform pages to their data sources.
+
+    Flushes the ORM unit of work first, so a constraint or validation
+    failure aborts the commit before any data source is touched. A
+    subsequent data-source write failure also aborts the commit and leaves
+    every staged page in place for a retry (pages already written are simply
+    rewritten with the same bytes).
+    """
+    staged = _base._pending.get(session)
+    if not staged:
+        return
+    # Surface ORM-level failures before writing any file: after this returns
+    # cleanly, only the raw COMMIT can still fail.
+    session.flush()
+    for (sourcename, datatype), data in staged.items():
+        logger.debug(f"Flushing staged seismogram data to {sourcename}.")
+        _base.write_seismogram_data(sourcename, datatype, data)
+    _base._pending.pop(session, None)
+
+
+@event.listens_for(Session, "after_soft_rollback")
+def _discard_pending(
+    session: Session, previous_transaction: SessionTransaction | None
+) -> None:
+    """Drop `session`'s staged pages on a full rollback, keep them on SAVEPOINT."""
+    if previous_transaction is not None and previous_transaction.nested:
+        return
+    _base._pending.pop(session, None)

--- a/src/aimbat/models/_models.py
+++ b/src/aimbat/models/_models.py
@@ -10,11 +10,11 @@ from pandas import Timestamp
 from pydantic import model_validator
 from pydantic.alias_generators import to_camel
 from sqlalchemy import CheckConstraint, Index, UniqueConstraint, func, text
-from sqlalchemy.orm import column_property
+from sqlalchemy.orm import column_property, object_session
 from sqlmodel import Field, Relationship, SQLModel, col, select
 from sqlmodel._compat import SQLModelConfig
 
-from aimbat.io import DataType, read_seismogram_data, write_seismogram_data
+from aimbat.io import DataType, read_seismogram_data, stage_seismogram_data
 from aimbat.types import (
     PydanticPositiveTimedelta,
     PydanticTimestamp,
@@ -517,7 +517,15 @@ class AimbatSeismogram(SQLModel, table=True):
 
     Holds timing information (`begin_time`, `delta`, `t0`) and a reference to
     the waveform data source; the waveform samples themselves are not stored
-    on this model but are read from and written to that data source on demand.
+    on this model but are read from that data source on demand.
+
+    Reading `data` returns a read-only array. Assigning `data` stages the
+    write in a per-session buffer and flushes it to the data source when the
+    owning session commits (and discards it on rollback), mirroring how ORM
+    column changes persist. Reads through the same session see the staged
+    value before the commit; other sessions do not. In-place mutation
+    (`seis.data[:] = ...`) is not supported. Assigning `data` on an instance
+    attached to no session falls back to an immediate write.
 
     Exposes the pysmo [`Seismogram`][pysmo.Seismogram] interface directly
     (`begin_time`, `delta`, `data`, `end_time`). ICCS working state (`t1`,
@@ -610,19 +618,28 @@ class AimbatSeismogram(SQLModel, table=True):
 
         @property
         def data(self) -> npt.NDArray[np.floating]:
-            """Seismogram waveform data array."""
+            """Seismogram waveform data as a read-only array.
+
+            Assigning to this attribute stages the write; it reaches the data
+            source when the owning session commits (see the class docstring).
+            """
             if self.datasource is None:
                 raise ValueError("Expected a valid datasource name, got None.")
             return read_seismogram_data(
-                self.datasource.sourcename, self.datasource.datatype
+                self.datasource.sourcename,
+                self.datasource.datatype,
+                object_session(self),
             )
 
         @data.setter
         def data(self, value: npt.NDArray[np.floating]) -> None:
             if self.datasource is None:
                 raise ValueError("Expected a valid datasource name, got None.")
-            write_seismogram_data(
-                self.datasource.sourcename, self.datasource.datatype, value
+            stage_seismogram_data(
+                object_session(self),
+                self.datasource.sourcename,
+                self.datasource.datatype,
+                value,
             )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,6 +102,20 @@ def mock_uuid4(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture(autouse=True)
+def clear_waveform_state() -> Generator[None]:
+    """Drop cached and staged waveform data after every test.
+
+    An uncommitted staged page left behind by one test would otherwise be
+    flushed to disk by a later test's unrelated `commit()`.
+    """
+    yield
+    from aimbat.io import _base
+
+    _base._cache.clear()
+    _base._pending.clear()
+
+
+@pytest.fixture(autouse=True)
 def mock_show(monkeypatch: pytest.MonkeyPatch) -> None:
     """Mocks plt.show to prevent plots from displaying during tests.
 

--- a/tests/integration/io/test_datasource_sac.py
+++ b/tests/integration/io/test_datasource_sac.py
@@ -14,13 +14,18 @@ from collections.abc import Generator
 from pathlib import Path
 
 import numpy as np
+import numpy.typing as npt
 import pytest
 from pandas import Timestamp
+from sqlalchemy import Engine
+from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session
 
 from pysmo.classes import SAC
 
+from aimbat.core import create_project
 from aimbat.io import DataType
+from aimbat.io import _base as io_base
 from aimbat.models import (
     AimbatDataSource,
     AimbatEvent,
@@ -259,8 +264,10 @@ class TestSacSeismogram:
         expected = seis.begin_time + seis.delta * (len(seis.data) - 1)
         assert seis.end_time == expected
 
-    def test_write_data_to_sac(self, sac_file_good: Path, session: Session) -> None:
-        """Verifies that writing to AimbatSeismogram.data updates the SAC file on disk.
+    def test_write_data_to_sac_deferred_until_commit(
+        self, sac_file_good: Path, session: Session
+    ) -> None:
+        """Assigning `data` stages the write; the SAC file changes only on commit.
 
         Args:
             sac_file_good (Path): Path to a valid SAC file.
@@ -273,7 +280,249 @@ class TestSacSeismogram:
         new_data = np.zeros_like(original_data)
         seis.data = new_data
 
-        # Re-read from disk to confirm the file was updated.
+        # File on disk is untouched, but this session sees the staged value.
+        on_disk = SAC.from_file(sac_file_good).seismogram.data
+        np.testing.assert_array_equal(on_disk, original_data)
+        np.testing.assert_array_equal(seis.data, new_data)
+
+        session.commit()
+
         reread = SAC.from_file(sac_file_good).seismogram.data
         np.testing.assert_array_equal(reread, new_data)
         assert not np.array_equal(reread, original_data)
+
+    def test_write_data_to_sac_discarded_on_rollback(
+        self, sac_file_good: Path, session: Session
+    ) -> None:
+        """A staged `data` write is dropped when the session rolls back.
+
+        Args:
+            sac_file_good (Path): Path to a valid SAC file.
+            session (Session): Database session.
+        """
+        seis = _persist_sac(session, sac_file_good)
+        session.refresh(seis)
+        original_data = seis.data.copy()
+
+        seis.data = np.zeros_like(original_data)
+        session.rollback()
+
+        np.testing.assert_array_equal(
+            SAC.from_file(sac_file_good).seismogram.data, original_data
+        )
+        # The next read (staging gone) returns the on-disk value.
+        np.testing.assert_array_equal(seis.data, original_data)
+
+    def test_staged_write_not_flushed_by_another_session(
+        self, sac_file_good: Path, engine_from_file: Engine
+    ) -> None:
+        """A second session committing does not flush the first session's stage.
+
+        This exercises `_pending` isolation between sessions, not concurrency
+        of the underlying SQLite store. A file-backed engine is used so the
+        two sessions get independent connections.
+
+        Args:
+            sac_file_good (Path): Path to a valid SAC file.
+            engine_from_file (Engine): File-backed test database engine.
+        """
+        create_project(engine_from_file)
+        # WAL so session B can commit a write while session A holds a read txn.
+        with engine_from_file.connect() as conn:
+            conn.exec_driver_sql("PRAGMA journal_mode=WAL")
+
+        with Session(engine_from_file) as session_a:
+            seis = _persist_sac(session_a, sac_file_good)
+            session_a.commit()
+            seismogram_id = seis.id
+            original_data = seis.data.copy()
+
+            seis.data = np.zeros_like(original_data)
+
+            with Session(engine_from_file) as session_b:
+                other = session_b.get(AimbatSeismogram, seismogram_id)
+                assert other is not None
+                other.t0 = other.begin_time
+                session_b.commit()
+
+            # Session B's commit did not flush session A's staged write.
+            np.testing.assert_array_equal(
+                SAC.from_file(sac_file_good).seismogram.data, original_data
+            )
+
+            session_a.commit()
+            np.testing.assert_array_equal(
+                SAC.from_file(sac_file_good).seismogram.data,
+                np.zeros_like(original_data),
+            )
+
+    def test_end_time_reflects_staged_sample_count(
+        self, sac_file_good: Path, session: Session
+    ) -> None:
+        """`end_time` uses the staged waveform length before commit.
+
+        Args:
+            sac_file_good (Path): Path to a valid SAC file.
+            session (Session): Database session.
+        """
+        seis = _persist_sac(session, sac_file_good)
+        session.refresh(seis)
+
+        shorter = seis.data[:10].copy()
+        seis.data = shorter
+        assert seis.end_time == seis.begin_time + seis.delta * 9
+
+    def test_clear_cache_keeps_staged_write(
+        self, sac_file_good: Path, session: Session
+    ) -> None:
+        """`clear_seismogram_data_cache` does not drop a staged `data` write.
+
+        Args:
+            sac_file_good (Path): Path to a valid SAC file.
+            session (Session): Database session.
+        """
+        from aimbat.io import clear_seismogram_data_cache
+
+        seis = _persist_sac(session, sac_file_good)
+        session.refresh(seis)
+        original_data = seis.data.copy()
+
+        seis.data = np.zeros_like(original_data)
+        clear_seismogram_data_cache()
+        session.commit()
+
+        np.testing.assert_array_equal(
+            SAC.from_file(sac_file_good).seismogram.data,
+            np.zeros_like(original_data),
+        )
+
+    def test_write_data_on_detached_instance_is_eager(
+        self, sac_file_good: Path, session: Session
+    ) -> None:
+        """With no owning session there is no transaction, so the write is eager.
+
+        Args:
+            sac_file_good (Path): Path to a valid SAC file.
+            session (Session): Database session.
+        """
+        seis = _persist_sac(session, sac_file_good)
+        session.commit()
+        original_data = seis.data.copy()
+        session.expunge(seis)
+        assert seis.datasource is not None  # loaded before expunge
+
+        seis.data = np.zeros_like(original_data)
+
+        # Written straight away, no commit needed.
+        np.testing.assert_array_equal(
+            SAC.from_file(sac_file_good).seismogram.data,
+            np.zeros_like(original_data),
+        )
+
+    def test_staged_write_survives_savepoint_rollback(
+        self, sac_file_good: Path, session: Session
+    ) -> None:
+        """A `begin_nested()` rollback keeps a write staged on the outer transaction.
+
+        Args:
+            sac_file_good (Path): Path to a valid SAC file.
+            session (Session): Database session.
+        """
+        seis = _persist_sac(session, sac_file_good)
+        session.commit()
+        original_data = seis.data.copy()
+
+        seis.data = np.zeros_like(original_data)
+
+        with pytest.raises(RuntimeError, match="abort savepoint"):
+            with session.begin_nested():
+                seis.t0 = seis.begin_time
+                raise RuntimeError("abort savepoint")
+
+        # Savepoint rolled back; the staged write is still pending.
+        np.testing.assert_array_equal(
+            SAC.from_file(sac_file_good).seismogram.data, original_data
+        )
+
+        session.commit()
+        np.testing.assert_array_equal(
+            SAC.from_file(sac_file_good).seismogram.data,
+            np.zeros_like(original_data),
+        )
+
+    def test_commit_failure_leaves_the_staged_write_retryable(
+        self,
+        sac_file_good: Path,
+        session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A failed flush aborts the commit; the staged write survives for a retry.
+
+        Args:
+            sac_file_good (Path): Path to a valid SAC file.
+            session (Session): Database session.
+            monkeypatch (pytest.MonkeyPatch): Fixture used to make the SAC
+                writer fail once.
+        """
+        seis = _persist_sac(session, sac_file_good)
+        session.commit()
+        original_data = seis.data.copy()
+        seis.data = np.zeros_like(original_data)
+
+        real_writer = io_base._seismogram_data_writers[DataType.SAC]
+        calls = {"n": 0}
+
+        def flaky_writer(src: str | Path, data: npt.NDArray[np.floating]) -> None:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise OSError("disk full")
+            real_writer(src, data)
+
+        monkeypatch.setitem(
+            io_base._seismogram_data_writers, DataType.SAC, flaky_writer
+        )
+
+        with pytest.raises(OSError, match="disk full"):
+            session.commit()
+
+        # First commit aborted: file untouched, write still staged.
+        np.testing.assert_array_equal(
+            SAC.from_file(sac_file_good).seismogram.data, original_data
+        )
+
+        session.commit()  # retry
+        np.testing.assert_array_equal(
+            SAC.from_file(sac_file_good).seismogram.data,
+            np.zeros_like(original_data),
+        )
+
+    def test_orm_flush_failure_leaves_the_data_source_untouched(
+        self, sac_file_good: Path, session: Session
+    ) -> None:
+        """A constraint failure at commit aborts before any file is written.
+
+        The flush listener flushes the ORM unit of work before touching a
+        data source, so an unrelated `IntegrityError` cannot leave the SAC
+        file ahead of the database.
+
+        Args:
+            sac_file_good (Path): Path to a valid SAC file.
+            session (Session): Database session.
+        """
+        seis = _persist_sac(session, sac_file_good)
+        session.commit()
+        original_data = seis.data.copy()
+
+        seis.data = np.zeros_like(original_data)
+        # A duplicate 1:1 parameters row trips the unique index at flush.
+        session.add(AimbatSeismogramParameters(seismogram_id=seis.id))
+
+        with pytest.raises(IntegrityError):
+            session.commit()
+
+        np.testing.assert_array_equal(
+            SAC.from_file(sac_file_good).seismogram.data, original_data
+        )
+
+        session.rollback()
+        np.testing.assert_array_equal(seis.data, original_data)

--- a/tests/unit/io/test_base_cache.py
+++ b/tests/unit/io/test_base_cache.py
@@ -1,18 +1,27 @@
 """Unit tests for the bounded waveform cache in `aimbat.io._base`."""
 
 from collections import OrderedDict
+from weakref import WeakKeyDictionary
 
 import numpy as np
 import pytest
+from sqlalchemy import create_engine
+from sqlmodel import Session
 
 from aimbat.io import _base
 from aimbat.io._data import DataType
 
 
+def _session() -> Session:
+    """A throwaway Session; these tests never touch the database through it."""
+    return Session(create_engine("sqlite://"))
+
+
 @pytest.fixture(autouse=True)
 def isolated_cache(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Give each test a fresh cache and a fake SAC reader."""
+    """Give each test a fresh cache, staging buffer, and a fake SAC reader."""
     monkeypatch.setattr(_base, "_cache", OrderedDict())
+    monkeypatch.setattr(_base, "_pending", WeakKeyDictionary())
     monkeypatch.setitem(
         _base._seismogram_data_readers,
         DataType.SAC,
@@ -53,3 +62,69 @@ def test_clear_seismogram_data_cache_empties_it() -> None:
     assert _base._cache
     _base.clear_seismogram_data_cache()
     assert not _base._cache
+
+
+def test_staged_value_shadows_lru_for_that_session_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setitem(
+        _base._seismogram_data_writers, DataType.SAC, lambda src, data: None
+    )
+    session = _session()
+    other = _session()
+
+    on_disk = _base.read_seismogram_data("x", DataType.SAC)  # populates the LRU
+    _base.stage_seismogram_data(session, "x", DataType.SAC, np.array([42.0]))
+
+    staged = _base.read_seismogram_data("x", DataType.SAC, session=session)
+    assert staged.tolist() == [42.0]
+    assert not staged.flags.writeable
+
+    # A different session, and the no-session path, still see the LRU value.
+    assert _base.read_seismogram_data("x", DataType.SAC, session=other) is on_disk
+    assert _base.read_seismogram_data("x", DataType.SAC) is on_disk
+
+
+def test_stage_copies_the_caller_array(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(
+        _base._seismogram_data_writers, DataType.SAC, lambda src, data: None
+    )
+    session = _session()
+    caller = np.array([1.0, 2.0])
+    _base.stage_seismogram_data(session, "x", DataType.SAC, caller)
+    caller[0] = 99.0
+
+    staged = _base.read_seismogram_data("x", DataType.SAC, session=session)
+    assert staged.tolist() == [1.0, 2.0]
+
+
+def test_stage_without_writer_raises() -> None:
+    with pytest.raises(NotImplementedError):
+        _base.stage_seismogram_data(
+            _session(), "x", DataType.JSON_EVENT, np.array([1.0])
+        )
+
+
+def test_stage_without_session_writes_eagerly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    written: list[tuple[object, object]] = []
+    monkeypatch.setitem(
+        _base._seismogram_data_writers,
+        DataType.SAC,
+        lambda src, data: written.append((src, data)),
+    )
+    _base.stage_seismogram_data(None, "x", DataType.SAC, np.array([7.0]))
+    assert written and written[0][0] == "x"
+
+
+def test_clear_cache_keeps_staged_pages(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(
+        _base._seismogram_data_writers, DataType.SAC, lambda src, data: None
+    )
+    session = _session()
+    _base.stage_seismogram_data(session, "x", DataType.SAC, np.array([5.0]))
+    _base.clear_seismogram_data_cache()
+    assert _base.read_seismogram_data("x", DataType.SAC, session=session).tolist() == [
+        5.0
+    ]

--- a/tests/unit/io/test_flush.py
+++ b/tests/unit/io/test_flush.py
@@ -1,0 +1,145 @@
+"""Unit tests for the session-scoped flush listeners in `aimbat.io._flush`.
+
+These call the listener functions directly with hand-built transaction
+objects. The event-surface behaviour they stand in for (`before_commit` /
+`after_soft_rollback` firing, and `nested` on a real SAVEPOINT rollback) is
+covered end to end in `tests/integration/io/test_datasource_sac.py`.
+"""
+
+from collections import OrderedDict
+from types import SimpleNamespace
+from weakref import WeakKeyDictionary
+
+import numpy as np
+import pytest
+from sqlalchemy import create_engine
+from sqlmodel import Session
+
+from aimbat.io import _base, _flush
+from aimbat.io._data import DataType
+
+
+def _session() -> Session:
+    """A throwaway Session; the listeners here never touch the database."""
+    return Session(create_engine("sqlite://"))
+
+
+def _txn(*, nested: bool) -> SimpleNamespace:
+    """Stand-in for the `SessionTransaction` passed to `after_soft_rollback`."""
+    return SimpleNamespace(nested=nested)
+
+
+@pytest.fixture(autouse=True)
+def isolated_state(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, list[float]]]:
+    """Fresh cache/staging buffers and a recording SAC writer."""
+    monkeypatch.setattr(_base, "_cache", OrderedDict())
+    monkeypatch.setattr(_base, "_pending", WeakKeyDictionary())
+    written: list[tuple[str, list[float]]] = []
+    monkeypatch.setitem(
+        _base._seismogram_data_writers,
+        DataType.SAC,
+        lambda src, data: written.append((str(src), list(data))),
+    )
+    return written
+
+
+def test_flush_writes_only_the_committing_session(
+    isolated_state: list[tuple[str, list[float]]],
+) -> None:
+    written = isolated_state
+    a, b = _session(), _session()
+    _base.stage_seismogram_data(a, "file_a", DataType.SAC, np.array([1.0]))
+    _base.stage_seismogram_data(b, "file_b", DataType.SAC, np.array([2.0]))
+
+    _flush._flush_pending(b)
+
+    assert written == [("file_b", [2.0])]
+    assert b not in _base._pending
+    assert a in _base._pending  # session A's stage is untouched
+
+
+def test_flush_invalidates_the_read_cache(
+    isolated_state: list[tuple[str, list[float]]],
+) -> None:
+    session = _session()
+    _base._cache[("file_a", DataType.SAC)] = np.array([0.0])
+    _base.stage_seismogram_data(session, "file_a", DataType.SAC, np.array([9.0]))
+
+    _flush._flush_pending(session)
+
+    assert ("file_a", DataType.SAC) not in _base._cache
+
+
+def test_full_rollback_discards_without_writing(
+    isolated_state: list[tuple[str, list[float]]],
+) -> None:
+    written = isolated_state
+    session = _session()
+    _base.stage_seismogram_data(session, "file_a", DataType.SAC, np.array([1.0]))
+
+    _flush._discard_pending(session, _txn(nested=False))
+
+    assert session not in _base._pending
+    assert written == []
+
+
+def test_savepoint_rollback_keeps_the_stage(
+    isolated_state: list[tuple[str, list[float]]],
+) -> None:
+    session = _session()
+    _base.stage_seismogram_data(session, "file_a", DataType.SAC, np.array([1.0]))
+
+    _flush._discard_pending(session, _txn(nested=True))
+
+    assert session in _base._pending
+
+
+def test_listeners_ignore_unknown_sessions(
+    isolated_state: list[tuple[str, list[float]]],
+) -> None:
+    _flush._flush_pending(_session())
+    _flush._discard_pending(_session(), _txn(nested=False))
+    _flush._discard_pending(_session(), None)
+    assert isolated_state == []
+
+
+def test_second_stage_for_the_same_source_replaces_the_first(
+    isolated_state: list[tuple[str, list[float]]],
+) -> None:
+    written = isolated_state
+    session = _session()
+    _base.stage_seismogram_data(session, "file_a", DataType.SAC, np.array([1.0]))
+    _base.stage_seismogram_data(session, "file_a", DataType.SAC, np.array([2.0]))
+
+    _flush._flush_pending(session)
+
+    assert written == [("file_a", [2.0])]
+
+
+def test_failed_flush_leaves_every_page_staged_for_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _session()
+    _base.stage_seismogram_data(session, "ok", DataType.SAC, np.array([1.0]))
+    _base.stage_seismogram_data(session, "boom", DataType.SAC, np.array([2.0]))
+
+    fail = {"on": True}
+
+    def flaky_writer(src: object, data: object) -> None:
+        if fail["on"] and str(src) == "boom":
+            raise OSError("disk full")
+
+    monkeypatch.setitem(_base._seismogram_data_writers, DataType.SAC, flaky_writer)
+
+    with pytest.raises(OSError, match="disk full"):
+        _flush._flush_pending(session)
+
+    # Nothing cleared: a retry commit rewrites "ok" and retries "boom".
+    assert set(_base._pending[session]) == {
+        ("ok", DataType.SAC),
+        ("boom", DataType.SAC),
+    }
+
+    fail["on"] = False
+    _flush._flush_pending(session)
+    assert session not in _base._pending

--- a/tests/unit/io/test_mseed.py
+++ b/tests/unit/io/test_mseed.py
@@ -149,6 +149,29 @@ class TestWriteSeismogramData:
         result = read_seismogram_data_from_mseedfile(mseed_file_good)
         np.testing.assert_allclose(result, data)
 
+    def test_deferred_stage_flushes_to_mseed(self, mseed_file_good: Path) -> None:
+        """A staged miniSEED write reaches the file only when the pending writes flush."""
+        from sqlalchemy import create_engine
+        from sqlmodel import Session
+
+        from aimbat.io import _base, _flush
+
+        original = read_seismogram_data_from_mseedfile(mseed_file_good)
+        new_data = np.ones_like(original) * 7.0
+        session = Session(create_engine("sqlite://"))
+
+        _base.stage_seismogram_data(
+            session, str(mseed_file_good), DataType.MSEED, new_data
+        )
+        np.testing.assert_array_equal(
+            read_seismogram_data_from_mseedfile(mseed_file_good), original
+        )
+
+        _flush._flush_pending(session)
+        np.testing.assert_array_equal(
+            read_seismogram_data_from_mseedfile(mseed_file_good), new_data
+        )
+
 
 # ===================================================================
 # capability registration


### PR DESCRIPTION
Staging `AimbatSeismogram.data` assignments in a per-session buffer and flushing them on `before_commit` (after `session.flush()` surfaces ORM errors first) makes waveform writes participate in the same commit/rollback lifecycle as database changes, instead of hitting the data source immediately at assignment time. Staged pages are dropped on a full rollback but kept across SAVEPOINT rollbacks, and a failed data-source write leaves pages in place for a retried commit.

The listeners are registered on the SQLAlchemy `Session` class so any session bound to the project database gets this behaviour, including ones opened outside AIMBAT's own code.

<!-- readthedocs-preview aimbat start -->
----
📚 Documentation preview 📚: https://aimbat--266.org.readthedocs.build/en/266/

<!-- readthedocs-preview aimbat end -->