### PR TITLE
refactor(io): treat datasource sourcename as an opaque source identifier

### DIFF
--- a/src/aimbat/_cli/data.py
+++ b/src/aimbat/_cli/data.py
@@ -1,9 +1,10 @@
 """Manage data sources in an AIMBAT project.
 
-A *data source* is a file that AIMBAT reads seismogram waveforms and metadata
-from. When a data source is added, AIMBAT extracts and stores the associated
-station, event, and seismogram records in the project database, provided the
-data type supports it.
+A *data source* is where AIMBAT reads seismogram waveforms and metadata from.
+Every current data type is a file, but a data source need not be one; it is
+identified by an opaque `sourcename`. When a data source is added, AIMBAT
+extracts and stores the associated station, event, and seismogram records in
+the project database, provided the data type supports it.
 
 **Supported data types** (`--type`):
 

--- a/src/aimbat/core/_data.py
+++ b/src/aimbat/core/_data.py
@@ -336,7 +336,8 @@ def _process_datasource(
 
     Args:
         session: Database session.
-        datasource: Path or identifier of the data source to process.
+        datasource: Logical source identifier of the data source to process
+            (a filesystem path for file-based sources).
         datatype: Type of data, which determines which of station, event, and
             seismogram creation are attempted.
         station_id: UUID of an existing station to link to instead of
@@ -568,6 +569,10 @@ def _seismogram_path(
     begin time, so re-ingesting the same triple again resolves to the same
     `sourcename` and is deduped by `_link_seismogram`/`_link_datasource`
     rather than creating a duplicate.
+
+    This is the seam that bakes the file assumption into the in-memory
+    ingestion path: it manufactures a filesystem-path `sourcename`. A future
+    non-file data source would replace this with its own identifier scheme.
     """
 
     filename = (

--- a/src/aimbat/io/__init__.py
+++ b/src/aimbat/io/__init__.py
@@ -1,13 +1,15 @@
 # flake8: noqa: E402, F403
 #
-"""File I/O for AIMBAT.
+"""I/O for AIMBAT data sources.
 
 Data source modules plug in by decorating their functions with the decorator
 factories from this package (`station_creator`, `event_creator`,
 `seismogram_creator`, `seismogram_data_reader`, `seismogram_data_writer`).
 Not every source needs to implement everything. A source that only provides
 waveform data would register a reader and writer but skip the creator
-functions.
+functions. A source is identified by an opaque `sourcename` string whose
+meaning is defined by the registered callbacks; for file-based sources it is
+a filesystem path, but non-file sources are free to use any identifier.
 
 SAC (`aimbat.io.sac`), JSON (`aimbat.io.json`), and miniSEED
 (`aimbat.io.mseed`) data sources are loaded automatically and their

--- a/src/aimbat/io/_base.py
+++ b/src/aimbat/io/_base.py
@@ -96,7 +96,7 @@ def register_station_creator(
 
     Args:
         datatype: The data type this creator handles.
-        fn: Callable that accepts a datasource path or name and returns an
+        fn: Callable that accepts a logical source identifier and returns an
             `AimbatStation` instance.
     """
     logger.debug(f"Registering station creator for {datatype}.")
@@ -111,7 +111,7 @@ def register_event_creator(
 
     Args:
         datatype: The data type this creator handles.
-        fn: Callable that accepts a datasource path or name and returns an
+        fn: Callable that accepts a logical source identifier and returns an
             `AimbatEvent` instance.
     """
     logger.debug(f"Registering event creator for {datatype}.")
@@ -126,7 +126,7 @@ def register_seismogram_creator(
 
     Args:
         datatype: The data type this creator handles.
-        fn: Callable that accepts a datasource path or name and returns an
+        fn: Callable that accepts a logical source identifier and returns an
             `AimbatSeismogram` instance.
     """
     logger.debug(f"Registering seismogram creator for {datatype}.")
@@ -141,7 +141,7 @@ def register_seismogram_data_reader(
 
     Args:
         datatype: The data type this reader handles.
-        fn: Callable that accepts a datasource path or name and returns the
+        fn: Callable that accepts a logical source identifier and returns the
             waveform data as a NumPy array.
     """
     logger.debug(f"Registering seismogram data reader for {datatype}.")
@@ -156,7 +156,7 @@ def register_seismogram_data_writer(
 
     Args:
         datatype: The data type this writer handles.
-        fn: Callable that accepts a datasource path or name and a NumPy array,
+        fn: Callable that accepts a logical source identifier and a NumPy array,
             and writes the data to the source.
     """
     logger.debug(f"Registering seismogram data writer for {datatype}.")
@@ -337,7 +337,7 @@ def create_station(
     """Create an `AimbatStation` from a data source.
 
     Args:
-        datasource: Data source path or name.
+        datasource: Logical source identifier for the data source.
         datatype: Data type of the source.
 
     Returns:
@@ -357,7 +357,7 @@ def create_event(datasource: str | PathLike[str], datatype: DataType) -> AimbatE
     """Create an `AimbatEvent` from a data source.
 
     Args:
-        datasource: Data source path or name.
+        datasource: Logical source identifier for the data source.
         datatype: Data type of the source.
 
     Returns:
@@ -379,7 +379,7 @@ def create_seismogram(
     """Create an `AimbatSeismogram` from a data source.
 
     Args:
-        datasource: Data source path or name.
+        datasource: Logical source identifier for the data source.
         datatype: Data type of the source.
 
     Returns:
@@ -410,7 +410,7 @@ def read_seismogram_data(
     the data source, so a session sees its own uncommitted waveform write.
 
     Args:
-        datasource: Data source path or name.
+        datasource: Logical source identifier for the data source.
         datatype: Data type of the source.
         session: Session whose staged writes should be consulted first.
 
@@ -457,7 +457,7 @@ def write_seismogram_data(
     listener in `aimbat.io._flush` calls this on the owning session's commit.
 
     Args:
-        datasource: Data source path or name.
+        datasource: Logical source identifier for the data source.
         datatype: Data type of the source.
         data: Seismogram waveform data to write.
 
@@ -505,7 +505,7 @@ def stage_seismogram_data(
 
     Args:
         session: The session that owns the seismogram, or `None`.
-        datasource: Data source path or name.
+        datasource: Logical source identifier for the data source.
         datatype: Data type of the source.
         data: Seismogram waveform data to write.
 

--- a/src/aimbat/io/_data.py
+++ b/src/aimbat/io/_data.py
@@ -2,7 +2,9 @@
 
 Defines the `DataType` enum used to route station, event, and seismogram
 creation and reading/writing to the data source registered for a given type,
-along with the file suffixes associated with each type.
+along with `DATATYPE_SUFFIXES`, which maps each type to its file suffixes.
+`DATATYPE_SUFFIXES` applies only to file-based sources (all current types);
+non-file sources of a given type are not described by it.
 """
 
 from enum import StrEnum, auto

--- a/src/aimbat/models/__init__.py
+++ b/src/aimbat/models/__init__.py
@@ -12,8 +12,8 @@ The main classes and their relationships are:
 - `AimbatSeismogram` — links an `AimbatEvent` to an `AimbatStation` and holds
   the timing metadata (`begin_time`, `delta`, `t0`). Waveform data are accessed
   via the associated `AimbatDataSource`.
-- `AimbatDataSource` — records where the waveform data for a seismogram are
-  stored, along with its type (e.g. SAC).
+- `AimbatDataSource` — identifies the logical source of the waveform data for a
+  seismogram and its type (e.g. SAC).
 - `AimbatEventParameters` — processing parameters shared across all seismograms
   of an event (window bounds, bandpass filter settings, MCCC settings, etc.).
 - `AimbatSeismogramParameters` — per-seismogram processing parameters

--- a/src/aimbat/models/_models.py
+++ b/src/aimbat/models/_models.py
@@ -1,6 +1,5 @@
 """ORM classes representing AIMBAT data stored in the database."""
 
-import os
 import uuid
 from typing import TYPE_CHECKING
 
@@ -51,7 +50,7 @@ __all__ = [
 class _AimbatDataSourceCreate(SQLModel):
     """Input model for creating a new data source entry."""
 
-    sourcename: os.PathLike[str] | str = Field(
+    sourcename: str = Field(
         unique=True,
     )
     datatype: DataType = Field(
@@ -60,7 +59,7 @@ class _AimbatDataSourceCreate(SQLModel):
 
 
 class AimbatDataSource(SQLModel, table=True):
-    """Location and format of the waveform data source for a seismogram."""
+    """Logical source identifier and format of the waveform data for a seismogram."""
 
     model_config = SQLModelConfig(
         alias_generator=to_camel,
@@ -83,7 +82,7 @@ class AimbatDataSource(SQLModel, table=True):
     )
     sourcename: str = Field(
         title="Source name",
-        description="Path or name of the data source.",
+        description="Opaque logical source identifier for the waveform data.",
     )
     datatype: DataType = Field(
         default=DataType.SAC,

--- a/uv.lock
+++ b/uv.lock
@@ -1864,8 +1864,8 @@ wheels = [
 
 [[package]]
 name = "pysmo"
-version = "1.0.0.dev177+gd33eb47db"
-source = { git = "https://github.com/pysmo/pysmo?rev=master#d33eb47db96cd963c13ccf828329d981f4a78709" }
+version = "1.0.0.dev192+g3b9501702"
+source = { git = "https://github.com/pysmo/pysmo?rev=master#3b950170299522ca8ce0d50176b510b588d72bbd" }
 dependencies = [
     { name = "annotated-types" },
     { name = "attrs" },


### PR DESCRIPTION
Narrow the stored AimbatDataSource.sourcename field to str and reword docstrings across the io, models, core and cli layers so a data source is an opaque logical identifier, not a filesystem path. Ingestion and dispatch signatures keep str | PathLike since file-based callers still pass Path objects.

Also bump the pysmo lock to dev192.

<!-- readthedocs-preview aimbat start -->
----
📚 Documentation preview 📚: https://aimbat--267.org.readthedocs.build/en/267/

<!-- readthedocs-preview aimbat end -->