### PR TITLE
refactor(io): pass readers a SeismogramReadContext

### DIFF
--- a/src/aimbat/io/_base.py
+++ b/src/aimbat/io/_base.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from collections import OrderedDict
 from collections.abc import Callable
+from dataclasses import dataclass
 from os import PathLike
 from typing import TYPE_CHECKING
 from weakref import WeakKeyDictionary
@@ -36,6 +37,7 @@ if TYPE_CHECKING:
 
 
 __all__ = [
+    "SeismogramReadContext",
     "clear_seismogram_data_cache",
     "create_event",
     "create_seismogram",
@@ -60,6 +62,19 @@ __all__ = [
     "write_seismogram_data",
 ]
 
+
+@dataclass(frozen=True, slots=True)
+class SeismogramReadContext:
+    """What a registered seismogram-data reader is handed for one read."""
+
+    sourcename: str
+    datatype: DataType
+    session: Session | None = None
+
+
+type SeismogramDataReader = Callable[[SeismogramReadContext], npt.NDArray[np.floating]]
+"""A registered seismogram-data reader: given a read context, return the waveform data as a NumPy array."""
+
 # LRU cache of waveform arrays keyed by (datasource, datatype); evicting an
 # entry only costs a re-read.
 _CACHE_MAX_ENTRIES = 1024
@@ -80,9 +95,7 @@ _event_creators: dict[DataType, Callable[[str | PathLike[str]], AimbatEvent]] = 
 _seismogram_creators: dict[
     DataType, Callable[[str | PathLike[str]], AimbatSeismogram]
 ] = {}
-_seismogram_data_readers: dict[
-    DataType, Callable[[str | PathLike[str]], npt.NDArray[np.floating]]
-] = {}
+_seismogram_data_readers: dict[DataType, SeismogramDataReader] = {}
 _seismogram_data_writers: dict[
     DataType, Callable[[str | PathLike[str], npt.NDArray[np.floating]], None]
 ] = {}
@@ -135,13 +148,13 @@ def register_seismogram_creator(
 
 def register_seismogram_data_reader(
     datatype: DataType,
-    fn: Callable[[str | PathLike[str]], npt.NDArray[np.floating]],
+    fn: SeismogramDataReader,
 ) -> None:
     """Register a function that reads seismogram waveform data from a data source.
 
     Args:
         datatype: The data type this reader handles.
-        fn: Callable that accepts a logical source identifier and returns the
+        fn: Callable that accepts a `SeismogramReadContext` and returns the
             waveform data as a NumPy array.
     """
     logger.debug(f"Registering seismogram data reader for {datatype}.")
@@ -250,10 +263,7 @@ def seismogram_creator(
 
 def seismogram_data_reader(
     datatype: DataType,
-) -> Callable[
-    [Callable[[str | PathLike[str]], npt.NDArray[np.floating]]],
-    Callable[[str | PathLike[str]], npt.NDArray[np.floating]],
-]:
+) -> Callable[[SeismogramDataReader], SeismogramDataReader]:
     """Decorator that registers a function as a seismogram data reader for `datatype`.
 
     Args:
@@ -263,14 +273,12 @@ def seismogram_data_reader(
         ```python
         @seismogram_data_reader(DataType.SAC)
         def read_seismogram_data_from_sacfile(
-            sacfile: str | PathLike[str],
+            context: SeismogramReadContext,
         ) -> npt.NDArray[np.floating]: ...
         ```
     """
 
-    def decorator(
-        fn: Callable[[str | PathLike[str]], npt.NDArray[np.floating]],
-    ) -> Callable[[str | PathLike[str]], npt.NDArray[np.floating]]:
+    def decorator(fn: SeismogramDataReader) -> SeismogramDataReader:
         register_seismogram_data_reader(datatype, fn)
         return fn
 
@@ -436,7 +444,10 @@ def read_seismogram_data(
         logger.debug(f"Retrieved seismogram data from cache for {datasource}.")
         _cache.move_to_end(key)
     else:
-        arr = reader(datasource)
+        context = SeismogramReadContext(
+            sourcename=key[0], datatype=datatype, session=session
+        )
+        arr = reader(context)
         arr.flags.writeable = False
         _cache[key] = arr
         if len(_cache) > _CACHE_MAX_ENTRIES:

--- a/src/aimbat/io/mseed.py
+++ b/src/aimbat/io/mseed.py
@@ -30,7 +30,11 @@ from pysmo.classes import MSeed
 
 from aimbat.logger import logger
 
-from ._base import seismogram_data_reader, seismogram_data_writer
+from ._base import (
+    SeismogramReadContext,
+    seismogram_data_reader,
+    seismogram_data_writer,
+)
 from ._data import DataType
 
 __all__ = [
@@ -41,12 +45,12 @@ __all__ = [
 
 @seismogram_data_reader(DataType.MSEED)
 def read_seismogram_data_from_mseedfile(
-    mseedfile: str | PathLike[str],
+    context: SeismogramReadContext,
 ) -> npt.NDArray[np.floating]:
     """Read seismogram waveform data from a miniSEED file.
 
     Args:
-        mseedfile: Name of the miniSEED file.
+        context: Read context whose `sourcename` names the miniSEED file.
 
     Returns:
         Seismogram amplitude data.
@@ -57,9 +61,9 @@ def read_seismogram_data_from_mseedfile(
             module docstring's scope boundary.
     """
 
-    logger.debug(f"Reading seismogram data from {mseedfile}.")
+    logger.debug(f"Reading seismogram data from {context.sourcename}.")
 
-    return MSeed.from_file(mseedfile).data
+    return MSeed.from_file(context.sourcename).data
 
 
 @seismogram_data_writer(DataType.MSEED)

--- a/src/aimbat/io/sac.py
+++ b/src/aimbat/io/sac.py
@@ -22,6 +22,7 @@ from aimbat import settings
 from aimbat.logger import logger
 
 from ._base import (
+    SeismogramReadContext,
     event_creator,
     seismogram_creator,
     seismogram_data_reader,
@@ -45,20 +46,20 @@ __all__ = [
 
 @seismogram_data_reader(DataType.SAC)
 def read_seismogram_data_from_sacfile(
-    sacfile: str | PathLike[str],
+    context: SeismogramReadContext,
 ) -> npt.NDArray[np.floating]:
     """Read seismogram waveform data from a SAC file.
 
     Args:
-        sacfile: Name of the SAC file.
+        context: Read context whose `sourcename` names the SAC file.
 
     Returns:
         Seismogram amplitude data.
     """
 
-    logger.debug(f"Reading seismogram data from {sacfile}.")
+    logger.debug(f"Reading seismogram data from {context.sourcename}.")
 
-    return SAC.from_file(sacfile).seismogram.data
+    return SAC.from_file(context.sourcename).seismogram.data
 
 
 @seismogram_data_writer(DataType.SAC)

--- a/tests/unit/io/test_base_cache.py
+++ b/tests/unit/io/test_base_cache.py
@@ -25,7 +25,7 @@ def isolated_cache(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setitem(
         _base._seismogram_data_readers,
         DataType.SAC,
-        lambda src: np.array([float(len(str(src)))]),
+        lambda context: np.array([float(len(context.sourcename))]),
     )
 
 
@@ -34,8 +34,8 @@ def test_lru_evicts_least_recently_used(monkeypatch: pytest.MonkeyPatch) -> None
 
     calls: list[str] = []
 
-    def recording_reader(src: object) -> np.ndarray:
-        calls.append(str(src))
+    def recording_reader(context: _base.SeismogramReadContext) -> np.ndarray:
+        calls.append(context.sourcename)
         return np.array([1.0])
 
     monkeypatch.setitem(_base._seismogram_data_readers, DataType.SAC, recording_reader)
@@ -116,6 +116,32 @@ def test_stage_without_session_writes_eagerly(
     )
     _base.stage_seismogram_data(None, "x", DataType.SAC, np.array([7.0]))
     assert written and written[0][0] == "x"
+
+
+def test_reader_receives_read_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[_base.SeismogramReadContext] = []
+
+    def capturing_reader(context: _base.SeismogramReadContext) -> np.ndarray:
+        seen.append(context)
+        return np.array([1.0])
+
+    monkeypatch.setitem(_base._seismogram_data_readers, DataType.SAC, capturing_reader)
+
+    _base.read_seismogram_data("x", DataType.SAC)
+    session = _session()
+    _base.read_seismogram_data("y", DataType.SAC, session=session)
+
+    assert isinstance(seen[0], _base.SeismogramReadContext)
+    assert (seen[0].sourcename, seen[0].datatype, seen[0].session) == (
+        "x",
+        DataType.SAC,
+        None,
+    )
+    assert (seen[1].sourcename, seen[1].datatype, seen[1].session) == (
+        "y",
+        DataType.SAC,
+        session,
+    )
 
 
 def test_clear_cache_keeps_staged_pages(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/io/test_mseed.py
+++ b/tests/unit/io/test_mseed.py
@@ -13,6 +13,7 @@ from pysmo.lib.io import write_mseed
 
 from aimbat.io import (
     DataType,
+    SeismogramReadContext,
     supports_event_creation,
     supports_seismogram_creation,
     supports_station_creation,
@@ -21,6 +22,10 @@ from aimbat.io.mseed import (
     read_seismogram_data_from_mseedfile,
     write_seismogram_data_to_mseedfile,
 )
+
+
+def _mseed_context(path: Path) -> SeismogramReadContext:
+    return SeismogramReadContext(str(path), DataType.MSEED)
 
 
 @pytest.fixture
@@ -97,41 +102,43 @@ class TestReadSeismogramData:
     """Tests for reading seismogram data from miniSEED files."""
 
     def test_returns_ndarray(self, mseed_file_good: Path) -> None:
-        data = read_seismogram_data_from_mseedfile(mseed_file_good)
+        data = read_seismogram_data_from_mseedfile(_mseed_context(mseed_file_good))
         assert isinstance(data, np.ndarray)
 
     def test_matches_pysmo_data(self, mseed_file_good: Path) -> None:
         expected = MSeed.from_file(mseed_file_good).data
-        data = read_seismogram_data_from_mseedfile(mseed_file_good)
+        data = read_seismogram_data_from_mseedfile(_mseed_context(mseed_file_good))
         np.testing.assert_array_equal(data, expected)
 
     def test_nonexistent_file_raises(self, tmp_path: Path) -> None:
         with pytest.raises(MiniSEEDError):
-            read_seismogram_data_from_mseedfile(tmp_path / "missing.mseed")
+            read_seismogram_data_from_mseedfile(
+                _mseed_context(tmp_path / "missing.mseed")
+            )
 
     def test_multichannel_file_raises_value_error(
         self, mseed_file_multichannel: Path
     ) -> None:
         """A multiplexed archival-style file is out of scope - see the module docstring."""
         with pytest.raises(ValueError):
-            read_seismogram_data_from_mseedfile(mseed_file_multichannel)
+            read_seismogram_data_from_mseedfile(_mseed_context(mseed_file_multichannel))
 
     def test_gappy_file_raises_value_error(self, mseed_file_gappy: Path) -> None:
         """A gappy archival-style file is out of scope - see the module docstring."""
         with pytest.raises(ValueError):
-            read_seismogram_data_from_mseedfile(mseed_file_gappy)
+            read_seismogram_data_from_mseedfile(_mseed_context(mseed_file_gappy))
 
 
 class TestWriteSeismogramData:
     """Tests for writing seismogram data to miniSEED files."""
 
     def test_overwrites_data_on_disk(self, mseed_file_good: Path) -> None:
-        original = read_seismogram_data_from_mseedfile(mseed_file_good)
+        original = read_seismogram_data_from_mseedfile(_mseed_context(mseed_file_good))
         new_data = np.ones_like(original) * 42.0
 
         write_seismogram_data_to_mseedfile(mseed_file_good, new_data)
 
-        reread = read_seismogram_data_from_mseedfile(mseed_file_good)
+        reread = read_seismogram_data_from_mseedfile(_mseed_context(mseed_file_good))
         np.testing.assert_array_equal(reread, new_data)
 
     def test_preserves_other_fields(self, mseed_file_good: Path) -> None:
@@ -146,7 +153,7 @@ class TestWriteSeismogramData:
     def test_round_trip(self, mseed_file_good: Path) -> None:
         data = np.linspace(-1.0, 1.0, 100)
         write_seismogram_data_to_mseedfile(mseed_file_good, data)
-        result = read_seismogram_data_from_mseedfile(mseed_file_good)
+        result = read_seismogram_data_from_mseedfile(_mseed_context(mseed_file_good))
         np.testing.assert_allclose(result, data)
 
     def test_deferred_stage_flushes_to_mseed(self, mseed_file_good: Path) -> None:
@@ -156,7 +163,7 @@ class TestWriteSeismogramData:
 
         from aimbat.io import _base, _flush
 
-        original = read_seismogram_data_from_mseedfile(mseed_file_good)
+        original = read_seismogram_data_from_mseedfile(_mseed_context(mseed_file_good))
         new_data = np.ones_like(original) * 7.0
         session = Session(create_engine("sqlite://"))
 
@@ -164,12 +171,14 @@ class TestWriteSeismogramData:
             session, str(mseed_file_good), DataType.MSEED, new_data
         )
         np.testing.assert_array_equal(
-            read_seismogram_data_from_mseedfile(mseed_file_good), original
+            read_seismogram_data_from_mseedfile(_mseed_context(mseed_file_good)),
+            original,
         )
 
         _flush._flush_pending(session)
         np.testing.assert_array_equal(
-            read_seismogram_data_from_mseedfile(mseed_file_good), new_data
+            read_seismogram_data_from_mseedfile(_mseed_context(mseed_file_good)),
+            new_data,
         )
 
 

--- a/tests/unit/io/test_sac.py
+++ b/tests/unit/io/test_sac.py
@@ -9,6 +9,7 @@ from pydantic import ValidationError
 
 from pysmo.classes import SAC
 
+from aimbat.io import DataType, SeismogramReadContext
 from aimbat.io.sac import (
     create_event_from_sacfile,
     create_seismogram_from_sacfile_and_pick_header,
@@ -17,6 +18,11 @@ from aimbat.io.sac import (
     write_seismogram_data_to_sacfile,
 )
 from aimbat.models import AimbatEvent, AimbatSeismogram, AimbatStation
+
+
+def _sac_context(path: Path) -> SeismogramReadContext:
+    return SeismogramReadContext(str(path), DataType.SAC)
+
 
 # ===================================================================
 # read / write seismogram data
@@ -32,7 +38,7 @@ class TestReadSeismogramData:
         Args:
             sac_file_good (Path): Path to a valid SAC file.
         """
-        data = read_seismogram_data_from_sacfile(sac_file_good)
+        data = read_seismogram_data_from_sacfile(_sac_context(sac_file_good))
         assert isinstance(data, np.ndarray)
 
     def test_matches_pysmo_data(self, sac_file_good: Path) -> None:
@@ -42,7 +48,7 @@ class TestReadSeismogramData:
             sac_file_good (Path): Path to a valid SAC file.
         """
         expected = SAC.from_file(sac_file_good).seismogram.data
-        data = read_seismogram_data_from_sacfile(sac_file_good)
+        data = read_seismogram_data_from_sacfile(_sac_context(sac_file_good))
         np.testing.assert_array_equal(data, expected)
 
     def test_nonexistent_file_raises(self, tmp_path: Path) -> None:
@@ -52,7 +58,7 @@ class TestReadSeismogramData:
             tmp_path (Path): Temporary directory path.
         """
         with pytest.raises(FileNotFoundError):
-            read_seismogram_data_from_sacfile(tmp_path / "missing.sac")
+            read_seismogram_data_from_sacfile(_sac_context(tmp_path / "missing.sac"))
 
 
 class TestWriteSeismogramData:
@@ -64,12 +70,12 @@ class TestWriteSeismogramData:
         Args:
             sac_file_good (Path): Path to a valid SAC file.
         """
-        original = read_seismogram_data_from_sacfile(sac_file_good)
+        original = read_seismogram_data_from_sacfile(_sac_context(sac_file_good))
         new_data = np.ones_like(original) * 42.0
 
         write_seismogram_data_to_sacfile(sac_file_good, new_data)
 
-        reread = read_seismogram_data_from_sacfile(sac_file_good)
+        reread = read_seismogram_data_from_sacfile(_sac_context(sac_file_good))
         np.testing.assert_array_equal(reread, new_data)
 
     def test_preserves_length(self, sac_file_good: Path) -> None:
@@ -78,9 +84,9 @@ class TestWriteSeismogramData:
         Args:
             sac_file_good (Path): Path to a valid SAC file.
         """
-        original = read_seismogram_data_from_sacfile(sac_file_good)
+        original = read_seismogram_data_from_sacfile(_sac_context(sac_file_good))
         write_seismogram_data_to_sacfile(sac_file_good, np.zeros_like(original))
-        reread = read_seismogram_data_from_sacfile(sac_file_good)
+        reread = read_seismogram_data_from_sacfile(_sac_context(sac_file_good))
         assert len(reread) == len(original)
 
     def test_round_trip(self, sac_file_good: Path) -> None:
@@ -92,7 +98,7 @@ class TestWriteSeismogramData:
         data = np.linspace(-1.0, 1.0, 100)
         # First overwrite with our data, then verify the round-trip.
         write_seismogram_data_to_sacfile(sac_file_good, data)
-        result = read_seismogram_data_from_sacfile(sac_file_good)
+        result = read_seismogram_data_from_sacfile(_sac_context(sac_file_good))
         np.testing.assert_allclose(result, data)
 
 


### PR DESCRIPTION
Registered seismogram-data readers now receive an immutable SeismogramReadContext (sourcename, datatype, session) instead of a bare path. read_seismogram_data keeps its public signature and builds the context on the cache-miss branch. Pure refactor, no behaviour change; groundwork for a future DB-backed PYSMO_PROJECT reader that needs the session.

<!-- readthedocs-preview aimbat start -->
----
📚 Documentation preview 📚: https://aimbat--270.org.readthedocs.build/en/270/

<!-- readthedocs-preview aimbat end -->