### PR TITLE
feat(data): add data prune for seismograms whose source has vanished

### DIFF
--- a/docs/first-steps/data.md
+++ b/docs/first-steps/data.md
@@ -61,6 +61,16 @@ Deletion follows the hierarchy:
     An event or station can exist without any seismogram, but a seismogram
     cannot exist without an event to record and a station to record it.
 
+`aimbat data prune` handles a vanished data source, such as a deleted SAC file
+or a moved directory. It removes every seismogram whose source can no longer be
+read. This is the batch, source-driven counterpart to the single-item `delete`
+commands.
+
+Permanent removal has two parts. First the data source is removed, by deleting
+the file or regenerating the source without the seismogram. Then
+`aimbat data prune` clears the leftover record. A seismogram can also stay in
+the project but sit out the analysis, with `select = False`.
+
 See [Removing data](../usage/data.md#removing-data) for the commands.
 
 ## Parameters

--- a/docs/usage/data.md
+++ b/docs/usage/data.md
@@ -11,12 +11,13 @@ Each file is validated before any record is written: required fields present,
 values in range, types correct. A file that fails validation is skipped and the
 database is left unchanged for it. Other files in the same batch still import.
 
-!!! warning "Files must remain accessible"
+!!! warning "Moved or deleted sources"
 
-    AIMBAT stores the path to each data file at import time. If a file is moved,
-    renamed, or deleted afterwards, AIMBAT can no longer read waveform data for
-    the associated seismogram. Keep data files in a stable location, or update
-    the path in the database before moving them.
+    AIMBAT stores the path to each data source at import time. A source that is
+    later moved, renamed, or deleted can no longer be read. The seismogram stays
+    broken until the original path is restored, or until
+    [`aimbat data prune`](#removing-data) drops it. Data sources are best kept in
+    a stable location while a project is in progress.
 
 ## Data types
 
@@ -482,3 +483,64 @@ or were added deliberately via JSON.
 
     Deleting a seismogram removes the database record and its link to the
     waveform source only. The underlying file is never modified.
+
+### Pruning vanished data sources
+
+`aimbat data prune` reconciles a project after a data source disappears, such as
+a deleted SAC file or a moved directory. It probes every data source in scope.
+Any seismogram whose source can no longer be read is deleted. This is the batch,
+source-driven counterpart to the single-item `delete` commands.
+
+```bash
+aimbat data prune all --dry-run          # preview; delete nothing
+aimbat data prune all                    # prune every event, with a prompt
+aimbat data prune <EVENT_ID>             # prune one event only
+```
+
+Permanent removal has two parts. First the data source is removed, by deleting
+the file or regenerating the source without the seismogram. Then `prune` clears
+the leftover record.
+
+`prune` only ever touches sources that have vanished. A source that is still
+readable is left alone, and a later `data add` would re-add anything it still
+provides. A seismogram that should stay in the project but sit out the analysis
+can be deselected with `select = False` instead.
+
+!!! warning "Moved is not deleted"
+
+    `prune` cannot tell a relocated file from a deleted one. A `--dry-run` first
+    shows what would be removed. If the data still exist elsewhere, restoring the
+    path is safer than pruning.
+
+    Sometimes a source's absence cannot be confirmed, for example when its
+    parent directory is gone or a mount is unreachable. `prune` then stops
+    rather than guessing. `--force` overrides this and treats the source as
+    gone.
+
+!!! tip "What prune repairs"
+
+    Pruning re-nulls the live ICCS/MCCC quality for every affected event. The
+    `align` and `mccc` steps need re-running afterwards. Each affected event is
+    snapshotted first, unless `--no-snapshot` is given.
+
+    Frozen snapshot history is preserved. A snapshot-derived operation such as
+    `build_iccs_from_snapshot` or a snapshot plot silently omits a pruned
+    seismogram.
+
+    By default only seismograms are deleted. `--prune-empty-stations` and
+    `--prune-empty-events` also remove stations or events left with nothing.
+    `--prune-empty-events` permanently destroys those events' snapshots. The dry
+    run and the prompt both report the count.
+
+From the API, [`prune_project`][aimbat.core.prune_project] returns a
+`PruneReport` that describes what was removed, or what a dry run would remove:
+
+```python
+from sqlmodel import Session
+from aimbat.core import prune_project
+from aimbat.db import engine
+
+with Session(engine) as session:
+    report = prune_project(session, "all", dry_run=True)
+    print(report.orphan_seismograms)
+```

--- a/src/aimbat/_cli/common/_decorators.py
+++ b/src/aimbat/_cli/common/_decorators.py
@@ -5,7 +5,12 @@ from typing import Any
 
 from aimbat import settings
 
-__all__ = ["confirm_or_abort", "handle_issues", "print_error_panel"]
+__all__ = [
+    "confirm_or_abort",
+    "handle_issues",
+    "print_error_panel",
+    "print_warning",
+]
 
 
 def print_error_panel(e: Exception) -> None:
@@ -24,7 +29,7 @@ def print_error_panel(e: Exception) -> None:
     console.print(panel)
 
 
-def _print_warning(message: object) -> None:
+def print_warning(message: object) -> None:
     """Print a non-fatal warning message to the console, styled yellow."""
     from rich.console import Console
     from rich.text import Text

--- a/src/aimbat/_cli/data.py
+++ b/src/aimbat/_cli/data.py
@@ -64,17 +64,21 @@ from sqlmodel import Session
 from aimbat.io import DataType
 
 from .common import (
+    ConfirmParameters,
     DebugParameter,
     JsonDumpParameters,
     TableParameters,
+    confirm_or_abort,
     event_parameter_is_all,
     event_parameter_with_all,
     handle_issues,
+    print_warning,
     use_event_parameter,
     use_station_parameter,
 )
 
 if TYPE_CHECKING:
+    from aimbat.core import PruneReport
     from aimbat.models import AimbatDataSource
 
 app = App(name="data", help=__doc__, help_format="markdown")
@@ -92,7 +96,6 @@ def _print_dry_run_results(
     from rich.console import Console
 
     from .common import json_to_table
-    from .common._decorators import _print_warning
 
     class _DryRunRow(BaseModel):
         source: str = Field(title="Source")
@@ -132,7 +135,7 @@ def _print_dry_run_results(
     )
 
     for message in duplicate_warnings:
-        _print_warning(message)
+        print_warning(message)
 
 
 @app.command(name="add")
@@ -245,13 +248,11 @@ def cli_data_add(
         elif auto_snapshot:
             from aimbat.core import create_snapshots_for_added_data
 
-            from .common._decorators import _print_warning
-
             _snapshotted, failures = create_snapshots_for_added_data(
                 session, added_datasources, existing_seismogram_ids
             )
             for event_id, error in failures:
-                _print_warning(
+                print_warning(
                     f"Could not create an automatic snapshot for event {event_id}: {error}"
                 )
 
@@ -327,6 +328,177 @@ def cli_data_list(
             raw=raw,
             col_specs=col_specs,
         )
+
+
+def _print_prune_report(
+    report: PruneReport, *, will_prune_stations: bool, will_prune_events: bool
+) -> None:
+    """Print a `PruneReport` as a table plus follow-up warning lines."""
+    from pydantic import BaseModel, Field
+    from rich.console import Console
+
+    from .common import json_to_table
+
+    console = Console()
+
+    if not report.orphan_seismograms:
+        console.print("No vanished data sources found.")
+    else:
+
+        class _OrphanRow(BaseModel):
+            source: str = Field(title="Source")
+            type: str = Field(title="Type")
+            station: str = Field(title="Station")
+            event: str = Field(title="Event")
+            reason: str = Field(title="Reason")
+
+        rows = []
+        for seis in report.orphan_seismograms:
+            sourcename, datatype = report.orphan_sources[seis.id]
+            rows.append(
+                {
+                    "source": sourcename,
+                    "type": str(datatype),
+                    "station": seis.station.name,
+                    "event": seis.event.time.strftime("%Y-%m-%d %H:%M:%S"),
+                    "reason": "source file missing",
+                }
+            )
+        json_to_table(rows, model=_OrphanRow, title="Data sources to prune")
+
+    for event in report.events_needing_invalidation:
+        console.print(
+            "Live ICCS/MCCC quality will be reset for event "
+            + event.time.strftime("%Y-%m-%d %H:%M:%S")
+            + " (re-run align / mccc)."
+        )
+
+    if report.emptied_stations:
+        verb = "removed" if will_prune_stations else "left empty"
+        console.print(f"{len(report.emptied_stations)} station(s) will be {verb}.")
+    if report.emptied_events:
+        if will_prune_events:
+            console.print(
+                f"{len(report.emptied_events)} emptied event(s) will be deleted."
+            )
+        else:
+            console.print(
+                f"{len(report.emptied_events)} event(s) will be left with no "
+                + "seismograms (pass --prune-empty-events to delete them)."
+            )
+
+    if report.total_snapshots:
+        print_warning(
+            f"{report.total_snapshots} snapshot(s) will be permanently deleted."
+        )
+    for category, count in report.cascaded_notes.items():
+        print_warning(f"{count} {category} note(s) will be deleted.")
+    for message in report.warnings:
+        print_warning(message)
+
+
+@app.command(name="prune")
+@handle_issues
+def cli_data_prune(
+    event_id: Annotated[uuid.UUID | Literal["all"], event_parameter_with_all()],
+    *,
+    dry_run: Annotated[
+        bool,
+        Parameter(
+            name="dry-run",
+            help="Show what would be pruned without deleting anything.",
+        ),
+    ] = False,
+    force: Annotated[
+        bool,
+        Parameter(
+            help=(
+                "Treat a source whose presence cannot be determined (an "
+                + "unreadable file, a missing parent directory, an unreachable "
+                + "mount) as vanished instead of stopping."
+            ),
+        ),
+    ] = False,
+    prune_empty_stations: Annotated[
+        bool,
+        Parameter(
+            name="prune-empty-stations",
+            help="Also delete stations left with no seismograms.",
+        ),
+    ] = False,
+    prune_empty_events: Annotated[
+        bool,
+        Parameter(
+            name="prune-empty-events",
+            help=(
+                "Also delete events left with no seismograms. This permanently "
+                + "destroys those events' snapshot history."
+            ),
+        ),
+    ] = False,
+    auto_snapshot: Annotated[
+        bool,
+        Parameter(
+            name="snapshot",
+            help="Snapshot every affected event before pruning.",
+        ),
+    ] = True,
+    confirm: ConfirmParameters = ConfirmParameters(),
+) -> None:
+    """Delete seismograms whose data source has vanished.
+
+    Reconciles the project with reality after a waveform source is removed (a
+    SAC file deleted, a directory moved). Each seismogram whose source can no
+    longer be read is deleted, along with its data source, parameters, and
+    quality records. Frozen snapshot history is preserved.
+
+    `prune` never deletes anything the source still provides. To remove a
+    seismogram whose data still exist, remove it from the source directory
+    first; to exclude one from analysis without deleting it, set `select =
+    False` instead.
+
+    Always run with `--dry-run` first: `prune` cannot tell a relocated file
+    from a deleted one. Pass `--prune-empty-stations` / `--prune-empty-events`
+    to also clean up stations or events left with no seismograms.
+    """
+    from aimbat.core import prune_project
+    from aimbat.db import engine
+
+    def confirm_prune(report: PruneReport) -> bool:
+        _print_prune_report(
+            report,
+            will_prune_stations=prune_empty_stations,
+            will_prune_events=prune_empty_events,
+        )
+        stations = len(report.emptied_stations) if prune_empty_stations else 0
+        events = len(report.emptied_events) if prune_empty_events else 0
+        confirm_or_abort(
+            f"Delete {len(report.orphan_seismograms)} seismogram(s) "
+            + f"(+ {stations} station(s), {events} event(s), "
+            + f"{report.total_snapshots} snapshot(s), {report.total_notes} note(s))?",
+            yes=confirm.yes,
+        )
+        return True
+
+    with Session(engine) as session:
+        report = prune_project(
+            session,
+            event_id,
+            dry_run=dry_run,
+            prune_empty_stations=prune_empty_stations,
+            prune_empty_events=prune_empty_events,
+            auto_snapshot=auto_snapshot,
+            force=force,
+            confirm=None if dry_run else confirm_prune,
+        )
+        # A dry run, or a live run with nothing to prune, never reaches the
+        # confirm callback, so the report is still unprinted here.
+        if dry_run or not report.orphan_seismograms:
+            _print_prune_report(
+                report,
+                will_prune_stations=prune_empty_stations,
+                will_prune_events=prune_empty_events,
+            )
 
 
 if __name__ == "__main__":

--- a/src/aimbat/core/__init__.py
+++ b/src/aimbat/core/__init__.py
@@ -29,6 +29,7 @@ from ._iccs import *
 from ._migrations import *
 from ._note import *
 from ._project import *
+from ._prune import *
 from ._seismogram import *
 from ._snapshot import *
 from ._station import *

--- a/src/aimbat/core/_iccs.py
+++ b/src/aimbat/core/_iccs.py
@@ -498,6 +498,58 @@ def clear_mccc_quality(session: Session, event: AimbatEvent) -> None:
     session.commit()
 
 
+def _invalidate_event_quality(session: Session, event_id: UUID) -> None:
+    """Null an event's live ICCS/MCCC quality and bump its `stack_modified`.
+
+    AIMBAT's quality-invalidation triggers are all `AFTER UPDATE` on a
+    parameter table, so removing a seismogram from an event (a delete, a
+    prune) fires none of them and leaves `AimbatEventQuality.mccc_rmse`, the
+    surviving seismograms' `iccs_cc` / MCCC stats, and `AimbatEvent.stack_modified`
+    stale. Callers that change an event's seismogram set must call this so
+    `SeismogramQualityStats.from_event` does not report numbers computed
+    against a seismogram set that no longer exists, and a warm `BoundICCS`
+    sees itself as stale.
+
+    Flushes but does not commit; the caller owns the transaction.
+
+    Args:
+        session: Database session.
+        event_id: Event whose live quality should be invalidated.
+    """
+    logger.debug(f"Invalidating live quality for event {event_id}.")
+
+    event = session.exec(
+        select(AimbatEvent)
+        .where(AimbatEvent.id == event_id)
+        .options(
+            selectinload(rel(AimbatEvent.quality)),
+            selectinload(rel(AimbatEvent.seismograms)).selectinload(
+                rel(AimbatSeismogram.quality)
+            ),
+        )
+    ).one_or_none()
+    if event is None:
+        return
+
+    if event.quality is not None:
+        event.quality.mccc_rmse = None
+        session.add(event.quality)
+
+    for seis in event.seismograms:
+        if seis.quality is not None:
+            seis.quality.iccs_cc = None
+            seis.quality.mccc_error = None
+            seis.quality.mccc_cc_mean = None
+            seis.quality.mccc_cc_std = None
+            session.add(seis.quality)
+
+    # `event` is already persistent, so the attribute change is tracked
+    # without `session.add()` - and adding it would cascade save-update along
+    # `seismograms`, which may still hold a just-deleted instance.
+    event.stack_modified = Timestamp.now("UTC")
+    session.flush()
+
+
 def build_iccs_from_snapshot(session: Session, snapshot_id: UUID) -> BoundICCS:
     """Build a read-only BoundICCS from a snapshot's parameters and live waveform data.
 

--- a/src/aimbat/core/_prune.py
+++ b/src/aimbat/core/_prune.py
@@ -1,0 +1,346 @@
+"""Reconcile an AIMBAT project with reality by pruning seismograms whose data source has vanished.
+
+`prune_project` probes every data source in scope (see
+`aimbat.io.source_present`), deletes the `AimbatSeismogram` rows whose source
+can no longer be read, and repairs the fallout a plain delete leaves behind:
+live ICCS/MCCC quality is re-nulled for every affected event (AIMBAT has no
+`AFTER DELETE` triggers), emptied stations and events are optionally cleaned
+up, and each affected event is snapshotted first.
+
+Frozen snapshot history survives a prune untouched: a pruned seismogram's
+`*Snapshot` rows keep their values and their own `seismogram_id`; only the
+back-links to the deleted live rows go `NULL`.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Literal
+from uuid import UUID
+
+from sqlalchemy import func
+from sqlalchemy.exc import NoResultFound
+from sqlalchemy.orm import selectinload
+from sqlmodel import Session, col, select
+
+from aimbat.io import (
+    DataType,
+    SourceUnavailableError,
+    clear_seismogram_data_cache,
+    source_present,
+    supports_source_probe,
+)
+from aimbat.logger import logger
+from aimbat.models import (
+    AimbatDataSource,
+    AimbatEvent,
+    AimbatNote,
+    AimbatSeismogram,
+    AimbatSnapshot,
+    AimbatStation,
+)
+from aimbat.utils import rel
+
+__all__ = ["PruneReport", "prune_project"]
+
+
+@dataclass
+class PruneReport:
+    """What `prune_project` found and (unless `dry_run`) did."""
+
+    orphan_seismograms: list[AimbatSeismogram]
+    """Seismograms whose data source probed absent."""
+    orphan_sources: dict[UUID, tuple[str, DataType]]
+    """Seismogram ID -> (sourcename, datatype) of the vanished source."""
+    unprobeable: dict[DataType, int]
+    """Datatype -> count of sources with no registered probe (reconcile incomplete)."""
+    emptied_stations: list[AimbatStation]
+    """Stations left with no seismograms once the orphans are gone."""
+    emptied_events: list[AimbatEvent]
+    """Events left with no seismograms; pruned only if `prune_empty_events`."""
+    events_needing_invalidation: list[AimbatEvent]
+    """Events that lose at least one seismogram and are not themselves pruned."""
+    deleted_snapshots: dict[UUID, int]
+    """Event ID -> number of snapshots destroyed by pruning that event."""
+    cascaded_notes: dict[str, int]
+    """"seismogram" | "station" | "event" -> count of notes cascade-deleted."""
+    warnings: list[str]
+    """Non-fatal warnings to surface to the user."""
+    dry_run: bool
+    pruned: bool = field(default=False)
+    """True once the deletions have been committed."""
+
+    @property
+    def total_snapshots(self) -> int:
+        """Total snapshots that will be, or were, destroyed."""
+        return sum(self.deleted_snapshots.values())
+
+    @property
+    def total_notes(self) -> int:
+        """Total notes that will be, or were, cascade-deleted."""
+        return sum(self.cascaded_notes.values())
+
+
+def _count_notes(session: Session, attr: str, ids: set[UUID]) -> int:
+    """Count `AimbatNote` rows whose `<attr>` is in `ids`."""
+    if not ids:
+        return 0
+    return session.exec(
+        select(func.count(col(AimbatNote.id))).where(
+            col(getattr(AimbatNote, attr)).in_(ids)
+        )
+    ).one()
+
+
+def prune_project(
+    session: Session,
+    event_id: UUID | Literal["all"],
+    *,
+    dry_run: bool = False,
+    prune_empty_stations: bool = False,
+    prune_empty_events: bool = False,
+    auto_snapshot: bool = True,
+    force: bool = False,
+    confirm: Callable[[PruneReport], bool] | None = None,
+) -> PruneReport:
+    """Delete seismograms whose data source can no longer be read.
+
+    Args:
+        session: Database session.
+        event_id: A single event's ID, or the literal `"all"` for the whole
+            project. Mirrors `aimbat data list`.
+        dry_run: Probe and report only; delete nothing.
+        prune_empty_stations: Also delete stations left with no seismograms.
+        prune_empty_events: Also delete events left with no seismograms.
+            Deleting an event irreversibly destroys its snapshot history.
+        auto_snapshot: Snapshot every affected event before deleting anything.
+            A snapshot failure aborts the prune with nothing deleted.
+        force: Treat a source whose presence cannot be determined (an
+            unreadable file, a missing parent directory, an unreachable mount)
+            as vanished instead of stopping. Without it, such a source is a
+            hard error and nothing is pruned.
+        confirm: Optional callback invoked once with the completed
+            `PruneReport` after probing but before any deletion (skipped on a
+            `dry_run` or when nothing is orphaned). Return `False` to abort
+            with nothing deleted; the same probe results are then used for the
+            deletion, so the user acts on exactly what was reported.
+
+    Returns:
+        A `PruneReport`.
+
+    Raises:
+        NoResultFound: If `event_id` is not `"all"` and names no event.
+        SourceUnavailableError: If a source's presence cannot be determined
+            and `force` is not set; nothing is pruned.
+        RuntimeError: If `auto_snapshot` is set and an affected event cannot
+            be snapshotted; nothing is pruned.
+    """
+    all_scope = isinstance(event_id, str) and event_id.lower() == "all"
+    if not all_scope and session.get(AimbatEvent, event_id) is None:
+        raise NoResultFound(f"No AimbatEvent found with id: {event_id}.")
+    scope_label = "all events" if all_scope else f"event {event_id}"
+    logger.info(f"Pruning {scope_label} (dry_run={dry_run}).")
+
+    # A column query, not an ORM-object one: holding `AimbatDataSource`
+    # instances in the session would make `session.delete(seismogram)` issue a
+    # redundant ORM DELETE for a row the DB-level `ON DELETE CASCADE` already
+    # removes.
+    source_stmt = select(
+        AimbatDataSource.sourcename,
+        AimbatDataSource.datatype,
+        AimbatDataSource.seismogram_id,
+    ).join(AimbatSeismogram)
+    if not all_scope:
+        source_stmt = source_stmt.where(AimbatSeismogram.event_id == event_id)
+    source_rows = session.exec(source_stmt).all()
+
+    warnings: list[str] = []
+    orphan_sources: dict[UUID, tuple[str, DataType]] = {}
+    unprobeable: dict[DataType, int] = {}
+    for sourcename, datatype_raw, seismogram_id in source_rows:
+        sourcename = str(sourcename)
+        datatype = DataType(datatype_raw)
+        if not supports_source_probe(datatype):
+            unprobeable[datatype] = unprobeable.get(datatype, 0) + 1
+            continue
+        try:
+            present = source_present(sourcename, datatype, session)
+        except SourceUnavailableError as exc:
+            if not force:
+                raise SourceUnavailableError(
+                    f"Cannot determine whether data source {sourcename!r} "
+                    + f"({datatype}) is present: {exc} Nothing was pruned. "
+                    + "Restore the path, or re-run with force if these data "
+                    + "are gone for good."
+                ) from exc
+            warnings.append(
+                f"force: treating {sourcename!r} ({datatype}) as vanished "
+                + f"even though its absence could not be confirmed ({exc})."
+            )
+            present = False
+        if not present:
+            orphan_sources[seismogram_id] = (sourcename, datatype)
+
+    orphan_ids = set(orphan_sources)
+    orphan_seismograms: list[AimbatSeismogram] = []
+    if orphan_ids:
+        orphan_seismograms = list(
+            session.exec(
+                select(AimbatSeismogram)
+                .where(col(AimbatSeismogram.id).in_(orphan_ids))
+                .options(
+                    selectinload(rel(AimbatSeismogram.station)),
+                    selectinload(rel(AimbatSeismogram.event)),
+                )
+            ).all()
+        )
+
+    affected_event_ids = {s.event_id for s in orphan_seismograms}
+    affected_station_ids = {s.station_id for s in orphan_seismograms}
+
+    events: list[AimbatEvent] = []
+    if affected_event_ids:
+        events = list(
+            session.exec(
+                select(AimbatEvent)
+                .where(col(AimbatEvent.id).in_(affected_event_ids))
+                .options(selectinload(rel(AimbatEvent.seismograms)))
+            ).all()
+        )
+    stations: list[AimbatStation] = []
+    if affected_station_ids:
+        stations = list(
+            session.exec(
+                select(AimbatStation)
+                .where(col(AimbatStation.id).in_(affected_station_ids))
+                .options(selectinload(rel(AimbatStation.seismograms)))
+            ).all()
+        )
+
+    emptied_events = [
+        e for e in events if all(s.id in orphan_ids for s in e.seismograms)
+    ]
+    emptied_event_ids = {e.id for e in emptied_events}
+    emptied_stations = [
+        st for st in stations if all(s.id in orphan_ids for s in st.seismograms)
+    ]
+
+    pruned_event_ids = emptied_event_ids if prune_empty_events else set()
+    events_needing_invalidation = [e for e in events if e.id not in pruned_event_ids]
+
+    deleted_snapshots: dict[UUID, int] = {}
+    if prune_empty_events:
+        for e in emptied_events:
+            count = session.exec(
+                select(func.count(col(AimbatSnapshot.id))).where(
+                    col(AimbatSnapshot.event_id) == e.id
+                )
+            ).one()
+            if count:
+                deleted_snapshots[e.id] = count
+
+    cascaded_notes: dict[str, int] = {}
+    seismogram_notes = _count_notes(session, "seismogram_id", orphan_ids)
+    if seismogram_notes:
+        cascaded_notes["seismogram"] = seismogram_notes
+    if prune_empty_stations:
+        station_notes = _count_notes(
+            session, "station_id", {st.id for st in emptied_stations}
+        )
+        if station_notes:
+            cascaded_notes["station"] = station_notes
+    if prune_empty_events:
+        event_notes = _count_notes(session, "event_id", emptied_event_ids)
+        if event_notes:
+            cascaded_notes["event"] = event_notes
+
+    for datatype, count in unprobeable.items():
+        warnings.append(
+            f"Could not check {count} {datatype} source(s); reconcile incomplete."
+        )
+
+    report = PruneReport(
+        orphan_seismograms=orphan_seismograms,
+        orphan_sources=orphan_sources,
+        unprobeable=unprobeable,
+        emptied_stations=emptied_stations,
+        emptied_events=emptied_events,
+        events_needing_invalidation=events_needing_invalidation,
+        deleted_snapshots=deleted_snapshots,
+        cascaded_notes=cascaded_notes,
+        warnings=warnings,
+        dry_run=dry_run,
+    )
+
+    if dry_run or not orphan_seismograms:
+        return report
+
+    if confirm is not None and not confirm(report):
+        logger.info("Prune cancelled before any deletion.")
+        return report
+
+    from ._iccs import _invalidate_event_quality, clear_iccs_cache
+    from ._snapshot import create_snapshot
+
+    invalidate_event_ids = [e.id for e in events_needing_invalidation]
+    prune_station_ids = [s.id for s in emptied_stations] if prune_empty_stations else []
+    prune_event_ids = [e.id for e in emptied_events] if prune_empty_events else []
+
+    # Detach the eagerly loaded report graph now, while its relationships are
+    # still populated. `create_snapshot` commits (expiring every attached
+    # instance) and every deletion below reloads its target by ID, so nothing
+    # past this point needs these instances bound to the session - but callers
+    # still read `report.orphan_seismograms[*].station` and friends afterwards.
+    session.expunge_all()
+
+    if auto_snapshot:
+        for event_uuid in invalidate_event_ids:
+            snap_event = session.get(AimbatEvent, event_uuid)
+            if snap_event is None:
+                continue
+            try:
+                create_snapshot(
+                    session,
+                    snap_event,
+                    comment="Automatic snapshot before prune",
+                    automatic=True,
+                )
+            except Exception as exc:
+                session.rollback()
+                raise RuntimeError(
+                    f"Aborting prune: could not snapshot event {event_uuid} "
+                    + f"first ({exc}). Nothing was deleted."
+                ) from exc
+
+    for event_uuid in invalidate_event_ids:
+        _invalidate_event_quality(session, event_uuid)
+
+    # Every deletion below reloads its target by ID with no relationships
+    # attached, so `session.delete()` leaves the 1:1 children (data source,
+    # parameters, quality) to the DB-level `ON DELETE CASCADE` instead of also
+    # issuing a redundant ORM DELETE for each - matching `core.delete_seismogram`.
+    for seismogram_uuid in orphan_ids:
+        seismogram = session.get(AimbatSeismogram, seismogram_uuid)
+        if seismogram is not None:
+            session.delete(seismogram)
+    session.flush()
+    for station_uuid in prune_station_ids:
+        station = session.get(AimbatStation, station_uuid)
+        if station is not None:
+            session.delete(station)
+    for event_uuid in prune_event_ids:
+        event = session.get(AimbatEvent, event_uuid)
+        if event is not None:
+            session.delete(event)
+    session.commit()
+
+    clear_seismogram_data_cache()
+    clear_iccs_cache()
+
+    report.pruned = True
+    pruned_stations = len(emptied_stations) if prune_empty_stations else 0
+    pruned_events = len(emptied_events) if prune_empty_events else 0
+    logger.info(
+        f"Pruned {len(orphan_seismograms)} seismogram(s), "
+        + f"{pruned_stations} station(s), {pruned_events} event(s)."
+    )
+    return report

--- a/src/aimbat/core/_seismogram.py
+++ b/src/aimbat/core/_seismogram.py
@@ -53,6 +53,16 @@ def delete_seismogram(session: Session, seismogram_id: UUID) -> None:
     if seismogram is None:
         raise NoResultFound(f"No AimbatSeismogram found with {seismogram_id=}")
 
+    from ._iccs import _invalidate_event_quality
+
+    event_id = seismogram.event_id
+    # No AFTER DELETE trigger fires, so the surviving seismograms' iccs_cc and
+    # the event RMSE would otherwise be left computed against a stack that
+    # still counted this one. Invalidate while every row is persistent: doing
+    # it after the delete flush can hit a preloaded event collection that
+    # still holds this seismogram and try to re-add its cascade-deleted
+    # quality child.
+    _invalidate_event_quality(session, event_id)
     session.delete(seismogram)
     session.commit()
 

--- a/src/aimbat/core/_snapshot.py
+++ b/src/aimbat/core/_snapshot.py
@@ -326,7 +326,7 @@ def create_snapshots_for_added_data(
         event IDs a snapshot was created for; `failures` is a list of
         `(event_id, error message)` for events whose snapshot failed. A
         failure is logged here; the caller decides how to surface it
-        (e.g. `_print_warning` on the CLI, a notification in the TUI).
+        (e.g. `print_warning` on the CLI, a notification in the TUI).
     """
     from collections import Counter
 

--- a/src/aimbat/core/_station.py
+++ b/src/aimbat/core/_station.py
@@ -47,6 +47,16 @@ def delete_station(session: Session, station_id: UUID) -> None:
     if station is None:
         raise NoResultFound(f"No AimbatStation found with {station_id=}")
 
+    from ._iccs import _invalidate_event_quality
+
+    # Deleting a station cascades to its seismograms across every event it
+    # recorded; none of those events' quality is invalidated by a trigger.
+    # Invalidate before deleting, while every seismogram row is still
+    # persistent: a post-delete pass can hit a preloaded event collection
+    # that still holds a cascade-deleted seismogram and its quality child.
+    affected_event_ids = {seis.event_id for seis in station.seismograms}
+    for event_id in affected_event_ids:
+        _invalidate_event_quality(session, event_id)
     session.delete(station)
     session.commit()
 

--- a/src/aimbat/io/_base.py
+++ b/src/aimbat/io/_base.py
@@ -6,16 +6,19 @@ providing waveform data only, for example, would register
 `register_seismogram_data_reader` and `register_seismogram_data_writer` but
 not the creator functions.
 
-The SAC data source (`aimbat.io._sac`) registers its capabilities
+The SAC data source (`aimbat.io.sac`) registers its capabilities
 automatically when imported.
 """
 
 from __future__ import annotations
 
+import os
+import stat as stat_module
 from collections import OrderedDict
 from collections.abc import Callable
 from dataclasses import dataclass
 from os import PathLike
+from pathlib import Path
 from typing import TYPE_CHECKING
 from weakref import WeakKeyDictionary
 
@@ -38,29 +41,44 @@ if TYPE_CHECKING:
 
 __all__ = [
     "SeismogramReadContext",
+    "SourceUnavailableError",
     "clear_seismogram_data_cache",
     "create_event",
     "create_seismogram",
     "create_station",
     "event_creator",
+    "file_source_present",
     "read_seismogram_data",
     "register_event_creator",
     "register_seismogram_creator",
     "register_seismogram_data_reader",
     "register_seismogram_data_writer",
+    "register_source_probe",
     "register_station_creator",
     "seismogram_creator",
     "seismogram_data_reader",
     "seismogram_data_writer",
+    "source_present",
+    "source_probe",
     "stage_seismogram_data",
     "station_creator",
     "supports_event_creation",
     "supports_seismogram_creation",
     "supports_seismogram_data_reading",
     "supports_seismogram_data_writing",
+    "supports_source_probe",
     "supports_station_creation",
     "write_seismogram_data",
 ]
+
+
+class SourceUnavailableError(Exception):
+    """A probe could not determine whether a data source is present.
+
+    Distinct from a clean "absent": raised when the answer is unknowable
+    right now (an unreadable file, an unreachable mount). `aimbat data prune`
+    treats this as a hard stop, never as a licence to delete.
+    """
 
 
 @dataclass(frozen=True, slots=True)
@@ -74,6 +92,14 @@ class SeismogramReadContext:
 
 type SeismogramDataReader = Callable[[SeismogramReadContext], npt.NDArray[np.floating]]
 """A registered seismogram-data reader: given a read context, return the waveform data as a NumPy array."""
+
+type SourcePresenceProbe = Callable[[SeismogramReadContext], bool]
+"""A registered source-presence probe: given a read context, return whether the source still provides this seismogram.
+
+Returns `True` when the source is reachable and provides the seismogram,
+`False` when it is reachable and definitely does not. Raises
+`SourceUnavailableError` when it cannot tell.
+"""
 
 # LRU cache of waveform arrays keyed by (datasource, datatype); evicting an
 # entry only costs a re-read.
@@ -99,6 +125,7 @@ _seismogram_data_readers: dict[DataType, SeismogramDataReader] = {}
 _seismogram_data_writers: dict[
     DataType, Callable[[str | PathLike[str], npt.NDArray[np.floating]], None]
 ] = {}
+_source_probes: dict[DataType, SourcePresenceProbe] = {}
 
 
 def register_station_creator(
@@ -174,6 +201,22 @@ def register_seismogram_data_writer(
     """
     logger.debug(f"Registering seismogram data writer for {datatype}.")
     _seismogram_data_writers[datatype] = fn
+
+
+def register_source_probe(
+    datatype: DataType,
+    fn: SourcePresenceProbe,
+) -> None:
+    """Register a function that checks whether a data source is still present.
+
+    Args:
+        datatype: The data type this probe handles.
+        fn: Callable that accepts a `SeismogramReadContext` and returns whether
+            the source still provides the seismogram, raising
+            `SourceUnavailableError` when it cannot tell.
+    """
+    logger.debug(f"Registering source presence probe for {datatype}.")
+    _source_probes[datatype] = fn
 
 
 def station_creator(
@@ -314,6 +357,28 @@ def seismogram_data_writer(
     return decorator
 
 
+def source_probe(
+    datatype: DataType,
+) -> Callable[[SourcePresenceProbe], SourcePresenceProbe]:
+    """Decorator that registers a function as a source-presence probe for `datatype`.
+
+    Args:
+        datatype: The data type the decorated function probes.
+
+    Example:
+        ```python
+        @source_probe(DataType.SAC)
+        def sac_source_present(context: SeismogramReadContext) -> bool: ...
+        ```
+    """
+
+    def decorator(fn: SourcePresenceProbe) -> SourcePresenceProbe:
+        register_source_probe(datatype, fn)
+        return fn
+
+    return decorator
+
+
 def supports_station_creation(datatype: DataType) -> bool:
     """Return whether `datatype` has a registered station creator."""
     return datatype in _station_creators
@@ -337,6 +402,77 @@ def supports_seismogram_data_reading(datatype: DataType) -> bool:
 def supports_seismogram_data_writing(datatype: DataType) -> bool:
     """Return whether `datatype` has a registered seismogram data writer."""
     return datatype in _seismogram_data_writers
+
+
+def supports_source_probe(datatype: DataType) -> bool:
+    """Return whether `datatype` has a registered source-presence probe."""
+    return datatype in _source_probes
+
+
+def source_present(
+    sourcename: str, datatype: DataType, session: Session | None = None
+) -> bool:
+    """Check whether a data source is still present and provides its seismogram.
+
+    Args:
+        sourcename: Logical source identifier for the data source.
+        datatype: Data type of the source.
+        session: Session made available to the probe (needed by sources whose
+            identity is resolved through the database).
+
+    Returns:
+        `True` if the source is reachable and provides the seismogram,
+        `False` if it is reachable and definitely does not.
+
+    Raises:
+        NotImplementedError: If `datatype` has no registered probe.
+        SourceUnavailableError: If the probe cannot determine presence right
+            now (e.g. an unreadable file or an unreachable mount).
+    """
+    probe = _source_probes.get(datatype)
+    if probe is None:
+        raise NotImplementedError(f"{datatype} does not support source probing.")
+    context = SeismogramReadContext(
+        sourcename=str(sourcename), datatype=datatype, session=session
+    )
+    return probe(context)
+
+
+def file_source_present(sourcename: str | PathLike[str]) -> bool:
+    """Return whether a filesystem-backed data source is present.
+
+    Shared implementation for the file-based probes (SAC, miniSEED, JSON). A
+    reachable regular file is present; a reachable directory that simply does
+    not contain the named entry is a clean `False`. Anything that leaves the
+    answer unknowable right now - a missing or unreadable parent directory (a
+    moved or unmounted tree), a permission error, an unreachable mount -
+    raises `SourceUnavailableError` rather than being mistaken for a deletion.
+
+    Args:
+        sourcename: Path to the file backing the data source.
+
+    Raises:
+        SourceUnavailableError: If presence cannot be determined right now.
+    """
+    path = Path(sourcename)
+    try:
+        mode = os.stat(path).st_mode
+    except FileNotFoundError as exc:
+        # The file is gone. Only trust that as a real deletion if the parent
+        # directory is still reachable; an unmounted volume whose mountpoint
+        # lingers would otherwise look like a clean absence.
+        if os.path.isdir(path.parent):
+            return False
+        raise SourceUnavailableError(
+            f"Neither {os.fspath(path)!r} nor its parent directory could be "
+            + "reached; this looks like a moved or unmounted data tree, not a "
+            + "deletion."
+        ) from exc
+    except OSError as exc:
+        raise SourceUnavailableError(
+            f"Could not determine whether {os.fspath(path)!r} is present: {exc}"
+        ) from exc
+    return stat_module.S_ISREG(mode)
 
 
 def create_station(

--- a/src/aimbat/io/json.py
+++ b/src/aimbat/io/json.py
@@ -38,7 +38,13 @@ from typing import TYPE_CHECKING
 
 from aimbat.logger import logger
 
-from ._base import event_creator, station_creator
+from ._base import (
+    SeismogramReadContext,
+    event_creator,
+    file_source_present,
+    source_probe,
+    station_creator,
+)
 from ._data import DataType
 
 if TYPE_CHECKING:
@@ -47,7 +53,24 @@ if TYPE_CHECKING:
 __all__ = [
     "create_event_from_json",
     "create_station_from_json",
+    "json_source_present",
 ]
+
+
+@source_probe(DataType.JSON_EVENT)
+@source_probe(DataType.JSON_STATION)
+def json_source_present(context: SeismogramReadContext) -> bool:
+    """Return whether the JSON file backing this record still exists.
+
+    Args:
+        context: Read context whose `sourcename` names the JSON file.
+
+    Raises:
+        SourceUnavailableError: If presence cannot be determined right now
+            (an unreadable file, a missing parent directory, an unreachable
+            mount).
+    """
+    return file_source_present(context.sourcename)
 
 
 def _load_json(path: str | PathLike[str]) -> object:

--- a/src/aimbat/io/mseed.py
+++ b/src/aimbat/io/mseed.py
@@ -32,15 +32,37 @@ from aimbat.logger import logger
 
 from ._base import (
     SeismogramReadContext,
+    file_source_present,
     seismogram_data_reader,
     seismogram_data_writer,
+    source_probe,
 )
 from ._data import DataType
 
 __all__ = [
+    "mseed_source_present",
     "read_seismogram_data_from_mseedfile",
     "write_seismogram_data_to_mseedfile",
 ]
+
+
+@source_probe(DataType.MSEED)
+def mseed_source_present(context: SeismogramReadContext) -> bool:
+    """Return whether the miniSEED file backing this seismogram still exists.
+
+    A miniSEED file written by `add_seismograms_to_project` is created once and
+    then treated exactly like any other external file, so a missing one is an
+    ordinary prunable orphan.
+
+    Args:
+        context: Read context whose `sourcename` names the miniSEED file.
+
+    Raises:
+        SourceUnavailableError: If presence cannot be determined right now
+            (an unreadable file, a missing parent directory, an unreachable
+            mount).
+    """
+    return file_source_present(context.sourcename)
 
 
 @seismogram_data_reader(DataType.MSEED)

--- a/src/aimbat/io/sac.py
+++ b/src/aimbat/io/sac.py
@@ -24,9 +24,11 @@ from aimbat.logger import logger
 from ._base import (
     SeismogramReadContext,
     event_creator,
+    file_source_present,
     seismogram_creator,
     seismogram_data_reader,
     seismogram_data_writer,
+    source_probe,
     station_creator,
 )
 from ._data import DataType
@@ -40,8 +42,24 @@ __all__ = [
     "create_seismogram_from_sacfile_and_pick_header",
     "create_station_from_sacfile",
     "read_seismogram_data_from_sacfile",
+    "sac_source_present",
     "write_seismogram_data_to_sacfile",
 ]
+
+
+@source_probe(DataType.SAC)
+def sac_source_present(context: SeismogramReadContext) -> bool:
+    """Return whether the SAC file backing this seismogram still exists.
+
+    Args:
+        context: Read context whose `sourcename` names the SAC file.
+
+    Raises:
+        SourceUnavailableError: If presence cannot be determined right now
+            (an unreadable file, a missing parent directory, an unreachable
+            mount).
+    """
+    return file_source_present(context.sourcename)
 
 
 @seismogram_data_reader(DataType.SAC)

--- a/tests/functional/test_cli_data_prune.py
+++ b/tests/functional/test_cli_data_prune.py
@@ -1,0 +1,138 @@
+"""Functional tests for the `aimbat data prune` CLI command.
+
+Commands are invoked in-process via `app()` with `aimbat.db.engine`
+monkeypatched to the test fixture's database.
+"""
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from sqlalchemy import Engine
+from sqlalchemy.exc import NoResultFound
+from sqlmodel import Session, select
+
+from aimbat.io import SourceUnavailableError
+from aimbat.models import AimbatDataSource, AimbatEvent, AimbatSeismogram
+
+
+def _sourcenames(engine: Engine) -> list[str]:
+    with Session(engine) as session:
+        return list(session.exec(select(AimbatDataSource.sourcename)).all())
+
+
+def _seismogram_count(engine: Engine) -> int:
+    with Session(engine) as session:
+        return len(session.exec(select(AimbatSeismogram)).all())
+
+
+@pytest.mark.cli
+class TestDataPrune:
+    def test_dry_run_lists_orphans_and_keeps_them(
+        self,
+        loaded_engine: Engine,
+        cli: Callable[[str], None],
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        before = _seismogram_count(loaded_engine)
+        Path(_sourcenames(loaded_engine)[0]).unlink()
+
+        cli("data prune all --dry-run")
+
+        out = capsys.readouterr().out
+        assert "Data sources to prune" in out
+        assert _seismogram_count(loaded_engine) == before
+
+    def test_prune_with_yes_deletes_orphan(
+        self,
+        loaded_engine: Engine,
+        cli: Callable[[str], None],
+    ) -> None:
+        before = _seismogram_count(loaded_engine)
+        gone = Path(_sourcenames(loaded_engine)[0])
+        gone.unlink()
+
+        cli("data prune all --yes --no-snapshot")
+
+        assert _seismogram_count(loaded_engine) == before - 1
+        assert gone.name not in [Path(s).name for s in _sourcenames(loaded_engine)]
+
+    def test_prune_declined_keeps_everything(
+        self,
+        loaded_engine: Engine,
+        cli: Callable[[str], None],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        before = _seismogram_count(loaded_engine)
+        Path(_sourcenames(loaded_engine)[0]).unlink()
+        monkeypatch.setattr("rich.prompt.Confirm.ask", lambda *a, **k: False)
+
+        cli("data prune all --no-snapshot")
+
+        assert _seismogram_count(loaded_engine) == before
+
+    def test_prune_nothing_to_do(
+        self,
+        loaded_engine: Engine,
+        cli: Callable[[str], None],
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        cli("data prune all --dry-run")
+        assert "No vanished data sources found." in capsys.readouterr().out
+
+    def test_missing_parent_directory_needs_force(
+        self,
+        loaded_engine: Engine,
+        cli: Callable[[str], None],
+        tmp_path: Path,
+    ) -> None:
+        with Session(loaded_engine) as session:
+            datasource = session.exec(select(AimbatDataSource)).first()
+            assert datasource is not None
+            datasource.sourcename = str(tmp_path / "vanished" / "x.sac")
+            session.add(datasource)
+            session.commit()
+
+        before = _seismogram_count(loaded_engine)
+        # Debug log level is on in tests, so handle_issues re-raises instead of
+        # exiting; a real terminal would see a red panel and exit 1.
+        with pytest.raises((SystemExit, SourceUnavailableError)):
+            cli("data prune all --yes --no-snapshot")
+
+        cli("data prune all --yes --no-snapshot --force")
+        assert _seismogram_count(loaded_engine) == before - 1
+
+    def test_unknown_event_id_errors(
+        self,
+        loaded_engine: Engine,
+        cli: Callable[[str], None],
+    ) -> None:
+        from uuid import uuid4
+
+        before = _seismogram_count(loaded_engine)
+        with pytest.raises((SystemExit, NoResultFound)):
+            cli(f"data prune {uuid4()} --yes --no-snapshot")
+        assert _seismogram_count(loaded_engine) == before
+
+    def test_scoped_to_single_event(
+        self,
+        loaded_engine: Engine,
+        cli: Callable[[str], None],
+    ) -> None:
+        with Session(loaded_engine) as session:
+            events = session.exec(select(AimbatEvent)).all()
+            target = events[0]
+            other = events[1]
+            target_source = Path(target.seismograms[0].datasource.sourcename)
+            other_source = Path(other.seismograms[0].datasource.sourcename)
+            other_event_id = other.id
+        target_source.unlink()
+        other_source.unlink()
+
+        before = _seismogram_count(loaded_engine)
+        cli(f"data prune {other_event_id} --yes --no-snapshot")
+
+        # Only the other event's orphan was removed; the target event's stays.
+        assert _seismogram_count(loaded_engine) == before - 1
+        assert not target_source.exists()
+        assert str(target_source) in _sourcenames(loaded_engine)

--- a/tests/integration/core/test_prune.py
+++ b/tests/integration/core/test_prune.py
@@ -1,0 +1,294 @@
+"""Integration tests for `aimbat.core.prune_project`."""
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy.exc import NoResultFound
+from sqlmodel import Session, select
+
+from aimbat.core import (
+    create_iccs_instance,
+    create_snapshot,
+    prune_project,
+    run_mccc,
+)
+from aimbat.io import DataType, SourceUnavailableError
+from aimbat.io._base import _source_probes
+from aimbat.models import (
+    AimbatDataSource,
+    AimbatEvent,
+    AimbatSeismogram,
+    AimbatSeismogramParameters,
+    AimbatSeismogramParametersSnapshot,
+    AimbatSeismogramQuality,
+    AimbatSnapshot,
+    AimbatStation,
+)
+
+
+def _first_event(session: Session) -> AimbatEvent:
+    event = session.exec(select(AimbatEvent)).first()
+    assert event is not None
+    return event
+
+
+def _unlink_seismogram_source(session: Session, seismogram: AimbatSeismogram) -> Path:
+    """Delete the file backing `seismogram` and return its path."""
+    path = Path(seismogram.datasource.sourcename)
+    path.unlink()
+    return path
+
+
+class TestPruneProject:
+    def test_dry_run_reports_but_keeps_everything(
+        self, loaded_session: Session
+    ) -> None:
+        event = _first_event(loaded_session)
+        seismogram = event.seismograms[0]
+        _unlink_seismogram_source(loaded_session, seismogram)
+
+        report = prune_project(loaded_session, "all", dry_run=True)
+
+        assert [s.id for s in report.orphan_seismograms] == [seismogram.id]
+        assert not report.pruned
+        assert loaded_session.get(AimbatSeismogram, seismogram.id) is not None
+
+    def test_prune_deletes_seismogram_and_cascades(
+        self, loaded_session: Session
+    ) -> None:
+        event = _first_event(loaded_session)
+        seismogram = event.seismograms[0]
+        seismogram_id = seismogram.id
+        datasource_id = seismogram.datasource.id
+        parameters_id = seismogram.parameters.id
+        _unlink_seismogram_source(loaded_session, seismogram)
+
+        report = prune_project(loaded_session, "all", auto_snapshot=False)
+
+        assert report.pruned
+        assert loaded_session.get(AimbatSeismogram, seismogram_id) is None
+        assert loaded_session.get(AimbatDataSource, datasource_id) is None
+        assert loaded_session.get(AimbatSeismogramParameters, parameters_id) is None
+
+    def test_report_graph_is_usable_after_auto_snapshot(
+        self, loaded_session: Session
+    ) -> None:
+        """The returned report's relationships must not be detached.
+
+        Regression: `create_snapshot`'s commit expired the report instances
+        and the later `expunge_all()` detached them, so
+        `orphan_seismograms[0].station` raised `DetachedInstanceError`.
+        """
+        event = _first_event(loaded_session)
+        seismogram = event.seismograms[0]
+        station_name = seismogram.station.name
+        _unlink_seismogram_source(loaded_session, seismogram)
+
+        report = prune_project(loaded_session, "all", auto_snapshot=True)
+
+        assert report.pruned
+        assert report.orphan_seismograms[0].station.name == station_name
+        assert report.orphan_seismograms[0].event.id == event.id
+
+    def test_frozen_snapshot_rows_survive_prune(self, loaded_session: Session) -> None:
+        event = _first_event(loaded_session)
+        seismogram = event.seismograms[0]
+        seismogram_id = seismogram.id
+        create_snapshot(loaded_session, event, comment="baseline")
+        snapshot = loaded_session.exec(select(AimbatSnapshot)).one()
+        snapshot_id = snapshot.id
+        count_before = snapshot.seismogram_count
+
+        _unlink_seismogram_source(loaded_session, seismogram)
+        prune_project(loaded_session, "all", auto_snapshot=False)
+
+        frozen = loaded_session.exec(
+            select(AimbatSeismogramParametersSnapshot).where(
+                AimbatSeismogramParametersSnapshot.seismogram_id == seismogram_id
+            )
+        ).one()
+        assert frozen.seismogram_parameters_id is None
+        refreshed = loaded_session.get(AimbatSnapshot, snapshot_id)
+        assert refreshed is not None
+        assert refreshed.seismogram_count == count_before
+
+    def test_live_quality_is_nulled_for_affected_event(
+        self, loaded_session: Session
+    ) -> None:
+        event = _first_event(loaded_session)
+        event_id = event.id
+        iccs_bound = create_iccs_instance(loaded_session, event)
+        run_mccc(loaded_session, event, iccs_bound.iccs, all_seismograms=False)
+        loaded_session.refresh(event)
+        assert event.quality is not None and event.quality.mccc_rmse is not None
+        stack_modified_before = event.stack_modified
+
+        surviving_id = event.seismograms[1].id
+        pruned = event.seismograms[0]
+        _unlink_seismogram_source(loaded_session, pruned)
+
+        prune_project(loaded_session, "all", auto_snapshot=False)
+
+        refreshed = loaded_session.get(AimbatEvent, event_id)
+        assert refreshed is not None
+        assert refreshed.quality is not None
+        assert refreshed.quality.mccc_rmse is None
+        assert refreshed.stack_modified != stack_modified_before
+        surviving_quality = loaded_session.exec(
+            select(AimbatSeismogramQuality).where(
+                AimbatSeismogramQuality.seismogram_id == surviving_id
+            )
+        ).one_or_none()
+        assert surviving_quality is not None
+        assert surviving_quality.iccs_cc is None
+        assert surviving_quality.mccc_cc_mean is None
+
+    def test_auto_snapshot_runs_before_delete(self, loaded_session: Session) -> None:
+        event = _first_event(loaded_session)
+        seismogram = event.seismograms[0]
+        _unlink_seismogram_source(loaded_session, seismogram)
+
+        seismograms_before = len(event.seismograms)
+        prune_project(loaded_session, "all", auto_snapshot=True)
+
+        snapshots = loaded_session.exec(
+            select(AimbatSnapshot).where(AimbatSnapshot.event_id == event.id)
+        ).all()
+        auto = [s for s in snapshots if s.comment == "Automatic snapshot before prune"]
+        assert len(auto) == 1
+        # The snapshot froze the pre-prune seismogram set.
+        assert auto[0].seismogram_count == seismograms_before
+
+    def test_snapshot_failure_aborts_without_deleting(
+        self, loaded_session: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        event = _first_event(loaded_session)
+        seismogram = event.seismograms[0]
+        seismogram_id = seismogram.id
+        _unlink_seismogram_source(loaded_session, seismogram)
+
+        def boom(*args: object, **kwargs: object) -> None:
+            raise RuntimeError("snapshot exploded")
+
+        monkeypatch.setattr("aimbat.core._snapshot.create_snapshot", boom)
+
+        with pytest.raises(RuntimeError, match="Aborting prune"):
+            prune_project(loaded_session, "all", auto_snapshot=True)
+
+        loaded_session.rollback()
+        assert loaded_session.get(AimbatSeismogram, seismogram_id) is not None
+
+    def test_no_snapshot_flag_suppresses_it(self, loaded_session: Session) -> None:
+        event = _first_event(loaded_session)
+        seismogram = event.seismograms[0]
+        _unlink_seismogram_source(loaded_session, seismogram)
+
+        prune_project(loaded_session, "all", auto_snapshot=False)
+
+        assert (
+            loaded_session.exec(
+                select(AimbatSnapshot).where(AimbatSnapshot.event_id == event.id)
+            ).first()
+            is None
+        )
+
+    def test_emptied_station_is_removed(self, loaded_session: Session) -> None:
+        station = loaded_session.exec(select(AimbatStation)).first()
+        assert station is not None
+        station_id = station.id
+        for seismogram in list(station.seismograms):
+            path = Path(seismogram.datasource.sourcename)
+            if path.exists():
+                path.unlink()
+
+        report = prune_project(
+            loaded_session, "all", prune_empty_stations=True, auto_snapshot=False
+        )
+
+        assert station_id in {s.id for s in report.emptied_stations}
+        assert loaded_session.get(AimbatStation, station_id) is None
+
+    def test_emptied_event_kept_without_flag(self, loaded_session: Session) -> None:
+        event = _first_event(loaded_session)
+        event_id = event.id
+        for seismogram in list(event.seismograms):
+            _unlink_seismogram_source(loaded_session, seismogram)
+
+        report = prune_project(loaded_session, event_id, auto_snapshot=False)
+
+        assert event_id in {e.id for e in report.emptied_events}
+        kept = loaded_session.get(AimbatEvent, event_id)
+        assert kept is not None
+        assert kept.seismograms == []
+
+    def test_emptied_event_pruned_with_flag_reports_snapshot_loss(
+        self, loaded_session: Session
+    ) -> None:
+        event = _first_event(loaded_session)
+        event_id = event.id
+        create_snapshot(loaded_session, event, comment="baseline")
+        for seismogram in list(event.seismograms):
+            _unlink_seismogram_source(loaded_session, seismogram)
+
+        report = prune_project(
+            loaded_session, event_id, prune_empty_events=True, auto_snapshot=False
+        )
+
+        assert loaded_session.get(AimbatEvent, event_id) is None
+        assert report.deleted_snapshots.get(event_id, 0) >= 1
+        assert (
+            loaded_session.exec(
+                select(AimbatSnapshot).where(AimbatSnapshot.event_id == event_id)
+            ).first()
+            is None
+        )
+
+    def test_unprobeable_datatype_warns_and_keeps_rows(
+        self, loaded_session: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delitem(_source_probes, DataType.SAC)
+        total = len(loaded_session.exec(select(AimbatSeismogram)).all())
+
+        report = prune_project(loaded_session, "all", auto_snapshot=False)
+
+        assert report.unprobeable.get(DataType.SAC) == total
+        assert not report.orphan_seismograms
+        assert len(loaded_session.exec(select(AimbatSeismogram)).all()) == total
+
+    def test_source_unavailable_aborts_without_deleting(
+        self, loaded_session: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _boom(_context: object) -> bool:
+            raise SourceUnavailableError("cannot stat")
+
+        monkeypatch.setitem(_source_probes, DataType.SAC, _boom)
+        event = _first_event(loaded_session)
+        count_before = len(event.seismograms)
+
+        with pytest.raises(SourceUnavailableError):
+            prune_project(loaded_session, "all", auto_snapshot=False)
+
+        loaded_session.refresh(event)
+        assert len(event.seismograms) == count_before
+
+    def test_missing_parent_directory_requires_force(
+        self, loaded_session: Session, tmp_path: Path
+    ) -> None:
+        event = _first_event(loaded_session)
+        seismogram = event.seismograms[0]
+        # Point the source at a path whose parent does not exist.
+        seismogram.datasource.sourcename = str(tmp_path / "gone" / "x.sac")
+        loaded_session.add(seismogram.datasource)
+        loaded_session.commit()
+
+        with pytest.raises(SourceUnavailableError, match="parent directory"):
+            prune_project(loaded_session, "all", auto_snapshot=False)
+
+        report = prune_project(loaded_session, "all", auto_snapshot=False, force=True)
+        assert report.pruned
+
+    def test_unknown_event_id_raises(self, loaded_session: Session) -> None:
+        from uuid import uuid4
+
+        with pytest.raises(NoResultFound):
+            prune_project(loaded_session, uuid4(), auto_snapshot=False)

--- a/tests/integration/core/test_seismogram.py
+++ b/tests/integration/core/test_seismogram.py
@@ -79,6 +79,37 @@ class TestDeleteSeismogram:
         with pytest.raises(NoResultFound):
             delete_seismogram(loaded_session, uuid.uuid4())
 
+    def test_delete_seismogram_with_preloaded_event_and_live_quality(
+        self, loaded_session: Session
+    ) -> None:
+        """Invalidation must not choke on an already-loaded event collection.
+
+        Regression: invalidating live quality after the delete flush could
+        walk a cached `event.seismograms` that still held the deleted
+        seismogram and try to re-add its cascade-deleted quality row.
+        """
+        from aimbat.core import create_iccs_instance
+        from aimbat.models import AimbatSeismogramQuality
+
+        event = loaded_session.exec(select(AimbatEvent)).first()
+        assert event is not None
+        create_iccs_instance(loaded_session, event)  # writes live iccs_cc
+
+        seismograms = list(event.seismograms)  # preload the collection
+        assert len(seismograms) > 1
+        victim_id, survivor_id = seismograms[0].id, seismograms[1].id
+        assert seismograms[0].quality is not None
+
+        delete_seismogram(loaded_session, victim_id)
+
+        assert loaded_session.get(AimbatSeismogram, victim_id) is None
+        survivor_quality = loaded_session.exec(
+            select(AimbatSeismogramQuality).where(
+                AimbatSeismogramQuality.seismogram_id == survivor_id
+            )
+        ).one()
+        assert survivor_quality.iccs_cc is None
+
 
 class TestSetSeismogramParameter:
     """Tests for writing parameter values to a seismogram instance."""

--- a/tests/integration/core/test_station.py
+++ b/tests/integration/core/test_station.py
@@ -56,6 +56,40 @@ class TestDeleteStation:
         with pytest.raises(NoResultFound):
             delete_station(loaded_session, uuid.uuid4())
 
+    def test_delete_station_with_preloaded_event_and_live_quality(
+        self, loaded_session: Session
+    ) -> None:
+        """Invalidation must not choke on an already-loaded event collection.
+
+        Regression: invalidating affected events after the cascade flush
+        could walk a cached `event.seismograms` still holding a
+        cascade-deleted seismogram and try to re-add its quality row.
+        """
+        from aimbat.core import create_iccs_instance
+        from aimbat.models import AimbatSeismogram, AimbatSeismogramQuality
+
+        event = loaded_session.exec(select(AimbatEvent)).first()
+        assert event is not None
+        create_iccs_instance(loaded_session, event)  # writes live iccs_cc
+
+        seismograms = list(event.seismograms)  # preload the collection
+        doomed = seismograms[0]
+        survivor = next(
+            (s for s in seismograms if s.station_id != doomed.station_id), None
+        )
+        assert survivor is not None
+        station_id, survivor_id = doomed.station_id, survivor.id
+
+        delete_station(loaded_session, station_id)
+
+        assert loaded_session.get(AimbatSeismogram, doomed.id) is None
+        survivor_quality = loaded_session.exec(
+            select(AimbatSeismogramQuality).where(
+                AimbatSeismogramQuality.seismogram_id == survivor_id
+            )
+        ).one()
+        assert survivor_quality.iccs_cc is None
+
 
 class TestGetStationsInEvent:
     """Tests for retrieving stations in a specific event."""

--- a/tests/unit/io/test_source_probe.py
+++ b/tests/unit/io/test_source_probe.py
@@ -1,0 +1,93 @@
+"""Unit tests for the source-presence probe capability in aimbat.io._base."""
+
+from pathlib import Path
+
+import pytest
+
+from aimbat.io import (
+    DataType,
+    SeismogramReadContext,
+    SourceUnavailableError,
+    file_source_present,
+    register_source_probe,
+    source_present,
+    supports_source_probe,
+)
+from aimbat.io._base import _source_probes
+
+
+def test_file_probes_registered() -> None:
+    """Every file-based data type ships a probe."""
+    for datatype in (
+        DataType.SAC,
+        DataType.MSEED,
+        DataType.JSON_EVENT,
+        DataType.JSON_STATION,
+    ):
+        assert supports_source_probe(datatype)
+
+
+def test_source_present_true_for_existing_file(tmp_path: Path) -> None:
+    """A present SAC file probes `True`."""
+    sacfile = tmp_path / "present.sac"
+    sacfile.write_bytes(b"")
+    assert source_present(str(sacfile), DataType.SAC) is True
+
+
+def test_source_present_false_for_missing_file(tmp_path: Path) -> None:
+    """A missing SAC file probes `False`."""
+    assert source_present(str(tmp_path / "gone.sac"), DataType.SAC) is False
+
+
+def test_missing_file_with_present_parent_is_clean_absent(tmp_path: Path) -> None:
+    """A gone file whose directory is still reachable probes `False`."""
+    assert file_source_present(tmp_path / "gone.sac") is False
+
+
+def test_missing_parent_directory_raises(tmp_path: Path) -> None:
+    """A gone file whose parent directory is also gone is unknowable."""
+    with pytest.raises(SourceUnavailableError, match="parent directory"):
+        file_source_present(tmp_path / "no_such_dir" / "x.sac")
+
+
+def test_unreadable_parent_directory_raises(tmp_path: Path) -> None:
+    """A file under a directory we cannot search is unknowable, not absent."""
+    locked = tmp_path / "locked"
+    locked.mkdir()
+    (locked / "x.sac").write_bytes(b"")
+    locked.chmod(0o000)
+    try:
+        result: object = file_source_present(locked / "x.sac")
+    except SourceUnavailableError:
+        return
+    finally:
+        locked.chmod(0o755)
+    if result is True:
+        pytest.skip("running as a user that bypasses directory permissions")
+    pytest.fail(f"expected SourceUnavailableError, got {result!r}")
+
+
+def test_source_present_unknown_datatype_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A data type with no registered probe raises `NotImplementedError`."""
+    monkeypatch.delitem(_source_probes, DataType.SAC)
+    assert not supports_source_probe(DataType.SAC)
+    with pytest.raises(NotImplementedError):
+        source_present("whatever", DataType.SAC)
+
+
+def test_probe_raising_source_unavailable_propagates() -> None:
+    """`SourceUnavailableError` from a probe is not swallowed."""
+    sentinel = DataType.SAC
+    original = _source_probes[sentinel]
+
+    def _boom(_context: SeismogramReadContext) -> bool:
+        raise SourceUnavailableError("mount unreachable")
+
+    register_source_probe(sentinel, _boom)
+    try:
+        with pytest.raises(SourceUnavailableError, match="mount unreachable"):
+            source_present("x", sentinel)
+    finally:
+        register_source_probe(sentinel, original)


### PR DESCRIPTION
`aimbat data prune <event-id|all>` probes every data source in scope and deletes the seismograms whose source can no longer be read, gated by `--dry-run` and a confirmation prompt. Emptied stations and events are left in place unless `--prune-empty-stations` / `--prune-empty-events` are passed; the latter also drops those events' snapshots. Frozen snapshot history survives the prune.

New `aimbat.io` source-presence probe capability: `source_present`, `file_source_present`, `SourceUnavailableError`, and probes for SAC, miniSEED and JSON. A source whose absence cannot be confirmed (missing parent directory, unreachable mount) is a hard stop unless `--force`.

Also closes a pre-existing gap: there is no AFTER DELETE trigger, so deleting a seismogram or station left the affected events' live ICCS/MCCC quality stale. `_invalidate_event_quality` now nulls it from `delete_seismogram`, `delete_station` and `prune`.

<!-- readthedocs-preview aimbat start -->
----
📚 Documentation preview 📚: https://aimbat--271.org.readthedocs.build/en/271/

<!-- readthedocs-preview aimbat end -->
