### PR TITLE
fix(tui): handle events with no seismograms without crashing

### DIFF
--- a/src/aimbat/_tui/_iccs_lifecycle.py
+++ b/src/aimbat/_tui/_iccs_lifecycle.py
@@ -22,7 +22,12 @@ from sqlmodel import Session
 from textual import work
 from textual.app import App
 
-from aimbat.core import BoundICCS, IccsLifecycle, create_iccs_instance
+from aimbat.core import (
+    BoundICCS,
+    IccsLifecycle,
+    NoSeismogramsError,
+    create_iccs_instance,
+)
 from aimbat.db import engine
 from aimbat.logger import logger
 from aimbat.models import AimbatEvent
@@ -105,8 +110,11 @@ class _IccsLifecycleMixin(App[None]):
             with Session(engine) as session:
                 event = self._get_current_event(session)
                 bound_iccs = create_iccs_instance(session, event)
-        except (NoResultFound, RuntimeError):
-            logger.debug("ICCS worker: no event selected or no data; aborting.")
+        except (NoResultFound, NoSeismogramsError, RuntimeError):
+            logger.debug(
+                "ICCS worker: no event selected, event has no seismograms, or "
+                + "no data; aborting."
+            )
             self.call_from_thread(self._iccs_lifecycle.mark_aborted)
             return
         except Exception as exc:

--- a/src/aimbat/_tui/_panels.py
+++ b/src/aimbat/_tui/_panels.py
@@ -697,7 +697,12 @@ class SeismogramPanel(Widget):
 
                 _populate_rows(table, rows, AimbatSeismogramRead)
 
-        stats = cc_stats(bound_iccs.iccs) if bound_iccs is not None else None
+        stats = None
+        if bound_iccs is not None:
+            # `cc_stats` reaches the stack, which raises for an ICCS instance
+            # with no (selected) seismograms.
+            with suppress(ValueError):
+                stats = cc_stats(bound_iccs.iccs)
         if stats is not None and stats.n_all > 0:
             table.border_title = (
                 "Seismograms  [dim]CC: selected "

--- a/src/aimbat/core/_iccs.py
+++ b/src/aimbat/core/_iccs.py
@@ -41,6 +41,7 @@ __all__ = [
     "BoundICCS",
     "CcStats",
     "IccsLifecycle",
+    "NoSeismogramsError",
     "build_iccs_from_snapshot",
     "cc_stats",
     "clear_iccs_cache",
@@ -52,6 +53,15 @@ __all__ = [
     "validate_iccs_construction",
     "write_back_seismograms",
 ]
+
+
+class NoSeismogramsError(RuntimeError):
+    """Raised when an ICCS instance is requested for an event with no seismograms.
+
+    An event with no seismograms has no stack, so any downstream access to
+    correlation values or the stack raises deep inside pysmo. Callers get
+    this clear, catchable error up front instead.
+    """
 
 
 @dataclass
@@ -323,14 +333,22 @@ def create_iccs_instance(session: Session, event: AimbatEvent) -> BoundICCS:
         )
     ).one()
 
+    if not event.seismograms:
+        raise NoSeismogramsError(
+            f"Event {event.id} has no seismograms; cannot build an ICCS instance."
+        )
+
     logger.debug(f"Creating ICCS instance for event {event.id}.")
     bound = BoundICCS(
         iccs=_build_iccs(event),
         event_id=event.id,
         created_at=created_at,
     )
-    _iccs_cache[event.id] = bound
+    # Cache only after the stats write succeeds: a half-initialised instance
+    # left in the cache would be returned (without re-raising) on the next
+    # call and blow up later on first stack access.
     _write_iccs_stats(event.id, bound.iccs)
+    _iccs_cache[event.id] = bound
     return bound
 
 

--- a/tests/functional/test_tui.py
+++ b/tests/functional/test_tui.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import cast
 
 import pytest
+from pandas import Timestamp
 from sqlalchemy import Engine
 from sqlmodel import Session, select
 from textual.binding import Binding
@@ -50,7 +51,12 @@ from aimbat.core import (
     get_head_revision,
 )
 from aimbat.core import create_iccs_instance as _real_create_iccs_instance
-from aimbat.models import AimbatEvent, AimbatSeismogram, AimbatSnapshot
+from aimbat.models import (
+    AimbatEvent,
+    AimbatEventParameters,
+    AimbatSeismogram,
+    AimbatSnapshot,
+)
 from aimbat.types import SeismogramParameter
 
 _TUI_SIZE = (120, 40)
@@ -535,6 +541,60 @@ class TestICCSStalenessRetry:
                 app._create_iccs()
                 await _wait_for_iccs_worker(app)
                 assert app._iccs_lifecycle._creating is False
+
+        asyncio.run(_run())
+
+
+@pytest.mark.slow
+class TestICCSEmptyEvent:
+    """Selecting an event with no seismograms must not crash the TUI.
+
+    Regression test: `create_iccs_instance` cached a half-built instance
+    before the stats write that raises for a seismogram-less event, so the
+    one-shot retry handed that broken instance to the panels, where
+    `cc_stats` blew up with `ValueError: Cannot create stack`.
+    """
+
+    def test_select_empty_event_does_not_crash(
+        self, loaded_engine_from_file: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_engine(monkeypatch, loaded_engine_from_file)
+
+        with Session(loaded_engine_from_file) as session:
+            empty = AimbatEvent(
+                time=Timestamp("2011-03-11T05:46:24", tz="UTC"),
+                latitude=38.30,
+                longitude=142.37,
+                depth=29.0,
+            )
+            session.add(empty)
+            session.flush()
+            session.add(AimbatEventParameters(event=empty))
+            session.commit()
+            empty_id = empty.id
+
+        async def _run() -> None:
+            async with AimbatTUI().run_test(size=_TUI_SIZE) as pilot:
+                app = cast(AimbatTUI, pilot.app)
+                await _wait_for_iccs_worker(app)
+
+                app._select_event(str(empty_id))
+                await _wait_for_iccs_worker(app)
+
+                assert app._iccs_lifecycle.bound is None
+                assert app._iccs_lifecycle.retry_pending is False
+
+                # The staleness poller must not resurrect a broken instance
+                # or start a retry storm.
+                app._check_iccs_staleness()
+                await _wait_for_iccs_worker(app)
+                app._check_iccs_staleness()
+                await pilot.pause(delay=0.3)
+
+                assert app._iccs_lifecycle.bound is None
+                assert app.is_running
+                bar = app.query_one("#event-bar", Static)
+                assert "no ICCS" in str(bar.render())
 
         asyncio.run(_run())
 

--- a/tests/integration/core/test_iccs.py
+++ b/tests/integration/core/test_iccs.py
@@ -1,16 +1,25 @@
 """Integration tests for ICCS alignment and MCCC quality clearing."""
 
+import pytest
+from pandas import Timestamp
 from sqlmodel import Session, select
 
 from aimbat.core import (
+    NoSeismogramsError,
     build_iccs_from_snapshot,
     cc_stats,
+    clear_iccs_cache,
     create_iccs_instance,
     create_snapshot,
     run_iccs,
     run_mccc,
 )
-from aimbat.models import AimbatEvent, AimbatSeismogramQuality, AimbatSnapshot
+from aimbat.models import (
+    AimbatEvent,
+    AimbatEventParameters,
+    AimbatSeismogramQuality,
+    AimbatSnapshot,
+)
 
 
 class TestIccsMcccInterplay:
@@ -226,6 +235,46 @@ class TestCcStats:
         assert stats.n_selected == 1
         assert stats.mean_selected is not None
         assert stats.sem_selected is None
+
+
+class TestCreateIccsInstanceNoSeismograms:
+    """`create_iccs_instance` on an event with no seismograms."""
+
+    @staticmethod
+    def _empty_event(session: Session) -> AimbatEvent:
+        event = AimbatEvent(
+            time=Timestamp("2010-02-27T06:34:14", tz="UTC"),
+            latitude=-36.12,
+            longitude=-72.90,
+            depth=22.9,
+        )
+        session.add(event)
+        session.flush()
+        session.add(AimbatEventParameters(event=event))
+        session.flush()
+        return event
+
+    def test_raises_no_seismograms_error(self, loaded_session: Session) -> None:
+        """A clean, catchable error rather than a failure deep inside pysmo."""
+        event = self._empty_event(loaded_session)
+        with pytest.raises(NoSeismogramsError):
+            create_iccs_instance(loaded_session, event)
+
+    def test_does_not_poison_the_cache(self, loaded_session: Session) -> None:
+        """A failed build must not leave a half-initialised instance cached.
+
+        Regression test: the broken instance used to be cached before the
+        stats write that raises, so the next call returned it without
+        re-raising and it blew up later on first stack access.
+        """
+        clear_iccs_cache()
+        event = self._empty_event(loaded_session)
+
+        with pytest.raises(NoSeismogramsError):
+            create_iccs_instance(loaded_session, event)
+        # Second call must raise again, not hand back a cached broken instance.
+        with pytest.raises(NoSeismogramsError):
+            create_iccs_instance(loaded_session, event)
 
 
 class TestBuildIccsFromSnapshot:


### PR DESCRIPTION
Selecting an event with no seismograms crashed the TUI with `ValueError: Cannot create stack: no seismograms are loaded`.

`create_iccs_instance` cached the BoundICCS before `_write_iccs_stats`, which raises for a seismogram-less event when it accesses the stack. The broken instance was left in the process-level cache and returned without re-raising on the next call (the one-shot retry), which then bound it and handed it to `SeismogramPanel`, where the unguarded `cc_stats` call blew up.

- raise `NoSeismogramsError` up front for an event with no seismograms, before any cache write, and cache the instance only after the stats write succeeds
- the TUI ICCS worker treats `NoSeismogramsError` as an expected abort (no error toast, no retry), like "no event selected"
- guard the `cc_stats` call in `SeismogramPanel.refresh_data` with `suppress(ValueError)`, matching the adjacent `iccs.ccs` guard

<!-- readthedocs-preview aimbat start -->
----
📚 Documentation preview 📚: https://aimbat--272.org.readthedocs.build/en/272/

<!-- readthedocs-preview aimbat end -->